### PR TITLE
更新到v1.0.1.6

### DIFF
--- a/Mirai-CSharp/Exceptions/BotMutedException.cs
+++ b/Mirai-CSharp/Exceptions/BotMutedException.cs
@@ -7,37 +7,24 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class BotMutedException : Exception
     {
+        private const string DefaultMessage = "给定的机器人QQ已被禁言。";
+
         /// <summary>
         /// 机器人QQ
         /// </summary>
         public long BotQQ { get; }
 
-        public BotMutedException() : this("给定的机器人QQ已被禁言。")
-        {
+        public BotMutedException() : this(DefaultMessage) { }
 
-        }
+        public BotMutedException(string message) : this(0, message) { }
 
-        public BotMutedException(string message) : base(message)
-        {
+        public BotMutedException(long botQQ) : this(botQQ, DefaultMessage, null) { }
 
-        }
+        public BotMutedException(long botQQ, string message) : this(botQQ, message, null) { }
 
-        public BotMutedException(long botQQ) : this(botQQ, "给定的机器人QQ已被禁言。", null)
-        {
+        public BotMutedException(string message, Exception? innerException) : this(0, message, innerException) { }
 
-        }
-
-        public BotMutedException(long botQQ, string message) : this(botQQ, message, null)
-        {
-
-        }
-
-        public BotMutedException(string message, Exception innerException) : base(message, innerException)
-        {
-
-        }
-
-        public BotMutedException(long botQQ, string message, Exception innerException) : base(message, innerException)
+        public BotMutedException(long botQQ, string message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             BotQQ = botQQ;
         }

--- a/Mirai-CSharp/Exceptions/BotNotFoundException.cs
+++ b/Mirai-CSharp/Exceptions/BotNotFoundException.cs
@@ -7,37 +7,24 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class BotNotFoundException : Exception
     {
+        public const string DefaultMessage = "给定的机器人QQ不存在。";
+
         /// <summary>
         /// 机器人QQ
         /// </summary>
         public long BotQQ { get; }
 
-        public BotNotFoundException() : this("给定的机器人QQ不存在。")
-        {
+        public BotNotFoundException() : this(DefaultMessage) { }
 
-        }
+        public BotNotFoundException(string? message) : this(0, message) { }
 
-        public BotNotFoundException(string message) : base(message)
-        {
+        public BotNotFoundException(long botQQ) : this(botQQ, DefaultMessage, null) { }
 
-        }
+        public BotNotFoundException(long botQQ, string? message) : this(botQQ, message, null) { }
 
-        public BotNotFoundException(long botQQ) : this(botQQ, "给定的机器人QQ不存在。", null)
-        {
+        public BotNotFoundException(string? message, Exception? innerException) : this(0, message, innerException) { }
 
-        }
-
-        public BotNotFoundException(long botQQ, string message) : this(botQQ, message, null)
-        {
-
-        }
-
-        public BotNotFoundException(string message, Exception innerException) : base(message, innerException)
-        {
-
-        }
-
-        public BotNotFoundException(long botQQ, string message, Exception innerException) : base(message, innerException)
+        public BotNotFoundException(long botQQ, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             BotQQ = botQQ;
         }

--- a/Mirai-CSharp/Exceptions/InvalidAuthKeyException.cs
+++ b/Mirai-CSharp/Exceptions/InvalidAuthKeyException.cs
@@ -7,32 +7,22 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class InvalidAuthKeyException : Exception
     {
+        private const string DefaultMessage = "错误的AuthKey。";
+
         /// <summary>
         /// 错误的AuthKey
         /// </summary>
-        public string AuthKey { get; }
+        public string? AuthKey { get; }
 
-        public InvalidAuthKeyException() : this(null, "错误的AuthKey。")
-        {
+        public InvalidAuthKeyException() : this(null, DefaultMessage) { }
 
-        }
+        public InvalidAuthKeyException(string? authKey) : this(authKey, DefaultMessage, null) { }
 
-        public InvalidAuthKeyException(string authKey) : this(authKey, "错误的AuthKey。", null)
-        {
+        public InvalidAuthKeyException(string? authKey, string? message) : this(authKey, message, null) { }
 
-        }
+        public InvalidAuthKeyException(string? message, Exception? innerException) : this(null, message, innerException) { }
 
-        public InvalidAuthKeyException(string authKey, string message) : this(authKey, message, null)
-        {
-
-        }
-
-        public InvalidAuthKeyException(string message, Exception innerException) : base(message, innerException)
-        {
-
-        }
-
-        public InvalidAuthKeyException(string authKey, string message, Exception innerException) : base(message, innerException)
+        public InvalidAuthKeyException(string? authKey, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             AuthKey = authKey;
         }

--- a/Mirai-CSharp/Exceptions/InvalidSessionException.cs
+++ b/Mirai-CSharp/Exceptions/InvalidSessionException.cs
@@ -7,32 +7,21 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class InvalidSessionException : Exception
     {
+        public const string DefaultMessage = "尝试操作一个失效, 不存在或未认证(未激活)的Session。";
         /// <summary>
         /// SessionKey
         /// </summary>
-        public string SessionKey { get; }
+        public string? SessionKey { get; }
 
-        public InvalidSessionException() : this(null, "尝试操作一个失效, 不存在或未认证(未激活)的Session。")
-        {
+        public InvalidSessionException() : this(null, DefaultMessage) { }
 
-        }
+        public InvalidSessionException(string? sessionKey) : this(sessionKey, DefaultMessage, null) { }
 
-        public InvalidSessionException(string sessionKey) : this(sessionKey, "尝试操作一个失效, 不存在或未认证(未激活)的Session。", null)
-        {
+        public InvalidSessionException(string? sessionKey, string? message) : this(sessionKey, message, null) { }
 
-        }
+        public InvalidSessionException(string? message, Exception? innerException) : this(null, message, innerException) { }
 
-        public InvalidSessionException(string sessionKey, string message) : this(sessionKey, message, null)
-        {
-
-        }
-
-        public InvalidSessionException(string message, Exception innerException) : base(message, innerException)
-        {
-
-        }
-
-        public InvalidSessionException(string sessionKey, string message, Exception innerException) : base(message, innerException)
+        public InvalidSessionException(string? sessionKey, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             SessionKey = sessionKey;
         }

--- a/Mirai-CSharp/Exceptions/MessageTooLongException.cs
+++ b/Mirai-CSharp/Exceptions/MessageTooLongException.cs
@@ -9,37 +9,23 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class MessageTooLongException : Exception
     {
+        private const string DefaultMessage = "消息过长。";
         /// <summary>
         /// 错误的AuthKey
         /// </summary>
-        public IMessageBase[] Chain { get; }
+        public IMessageBase[]? Chain { get; }
 
-        public MessageTooLongException() : this(null, "消息过长。")
-        {
+        public MessageTooLongException() : this(null, DefaultMessage) { }
 
-        }
+        public MessageTooLongException(IMessageBase[]? chain) : this(chain, DefaultMessage, null) { }
 
-        public MessageTooLongException(IMessageBase[] chain) : this(chain, "消息过长。", null)
-        {
+        public MessageTooLongException(string? message) : this(null, message, null) { }
 
-        }
+        public MessageTooLongException(IMessageBase[]? chain, string? message) : this(chain, message, null) { }
 
-        public MessageTooLongException(string message) : base(message)
-        {
+        public MessageTooLongException(string? message, Exception? innerException) : this(null, message, innerException) { }
 
-        }
-
-        public MessageTooLongException(IMessageBase[] chain, string message) : this(chain, message, null)
-        {
-
-        }
-
-        public MessageTooLongException(string message, Exception innerException) : base(message, innerException)
-        {
-
-        }
-
-        public MessageTooLongException(IMessageBase[] chain, string message, Exception innerException) : base(message, innerException)
+        public MessageTooLongException(IMessageBase[]? chain, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             Chain = chain;
         }

--- a/Mirai-CSharp/Exceptions/PermissionDeniedException.cs
+++ b/Mirai-CSharp/Exceptions/PermissionDeniedException.cs
@@ -7,37 +7,24 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class PermissionDeniedException : Exception
     {
+        private const string DefaultMessage = "给定的机器人QQ不具有对应操作的权限。";
+
         /// <summary>
         /// 机器人QQ
         /// </summary>
         public long BotQQ { get; }
 
-        public PermissionDeniedException() : this("给定的机器人QQ不具有对应操作的权限。")
-        {
+        public PermissionDeniedException() : this(DefaultMessage) { }
 
-        }
+        public PermissionDeniedException(string? message) : this(0, message) { }
 
-        public PermissionDeniedException(string message) : base(message)
-        {
+        public PermissionDeniedException(long botQQ) : this(botQQ, DefaultMessage, null) { }
 
-        }
+        public PermissionDeniedException(long botQQ, string? message) : this(botQQ, message, null) { }
 
-        public PermissionDeniedException(long botQQ) : this(botQQ, "给定的机器人QQ不具有对应操作的权限。", null)
-        {
+        public PermissionDeniedException(string? message, Exception? innerException) : this(0, message, innerException) { }
 
-        }
-
-        public PermissionDeniedException(long botQQ, string message) : this(botQQ, message, null)
-        {
-
-        }
-
-        public PermissionDeniedException(string message, Exception innerException) : base(message, innerException)
-        {
-
-        }
-
-        public PermissionDeniedException(long botQQ, string message, Exception innerException) : base(message, innerException)
+        public PermissionDeniedException(long botQQ, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             BotQQ = botQQ;
         }

--- a/Mirai-CSharp/Exceptions/TargetNotFoundException.cs
+++ b/Mirai-CSharp/Exceptions/TargetNotFoundException.cs
@@ -7,40 +7,27 @@ namespace Mirai_CSharp.Exceptions
     /// </summary>
     public sealed class TargetNotFoundException : Exception
     {
-        internal string _message; // 允许更改异常消息, 并且避免重新抛出异常时丢失StackTrace
+        private const string DefaultMessage = "给定的目标QQ/群号不存在。";
 
+        internal string? _message; // 允许更改异常消息, 并且避免重新抛出异常时丢失StackTrace
+        /// <inheritdoc/>
         public override string Message => _message ?? base.Message;
         /// <summary>
         /// 目标QQ/群号
         /// </summary>
         public long Target { get; }
 
-        public TargetNotFoundException() : this("给定的目标QQ/群号不存在。")
-        {
+        public TargetNotFoundException() : this(DefaultMessage) { }
 
-        }
+        public TargetNotFoundException(string? message) : this(0, message) { }
 
-        public TargetNotFoundException(string message) : base(message)
-        {
-            _message = message;
-        }
+        public TargetNotFoundException(long target) : this(target, DefaultMessage, null) { }
 
-        public TargetNotFoundException(long target) : this(target, "给定的目标QQ/群号不存在。", null)
-        {
+        public TargetNotFoundException(long target, string? message) : this(target, message, null) { }
 
-        }
+        public TargetNotFoundException(string? message, Exception? innerException) : this(0, message, innerException) { }
 
-        public TargetNotFoundException(long target, string message) : this(target, message, null)
-        {
-            _message = message;
-        }
-
-        public TargetNotFoundException(string message, Exception innerException) : base(message, innerException)
-        {
-            _message = message;
-        }
-
-        public TargetNotFoundException(long target, string message, Exception innerException) : base(message, innerException)
+        public TargetNotFoundException(long target, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
         {
             Target = target;
             _message = message;

--- a/Mirai-CSharp/Exceptions/UnknownResponseException.cs
+++ b/Mirai-CSharp/Exceptions/UnknownResponseException.cs
@@ -4,17 +4,19 @@ namespace Mirai_CSharp.Exceptions
 {
     public sealed class UnknownResponseException : Exception
     {
-        public string Response { get; }
+        private const string DefaultMessage = "未知的服务器返回。";
+
+        public string? Response { get; }
 
         public UnknownResponseException() { }
 
-        public UnknownResponseException(string response) : this(response, "未知的服务器返回.", null) { }
+        public UnknownResponseException(string? response) : this(response, DefaultMessage, null) { }
 
-        public UnknownResponseException(string response, string message) : this(response, message, null) { }
+        public UnknownResponseException(string? response, string? message) : this(response, message, null) { }
 
-        public UnknownResponseException(string response, Exception innerException) : this(response, "未知的服务器返回.", innerException) { }
+        public UnknownResponseException(string? response, Exception? innerException) : this(response, DefaultMessage, innerException) { }
 
-        public UnknownResponseException(string response, string message, Exception innerException) : base(message, innerException)
+        public UnknownResponseException(string? response, string? message, Exception? innerException) : base(message ?? DefaultMessage, innerException)
             => Response = response;
     }
 }

--- a/Mirai-CSharp/Helpers/HttpHelper.cs
+++ b/Mirai-CSharp/Helpers/HttpHelper.cs
@@ -16,12 +16,12 @@ namespace Mirai_CSharp.Helpers
 
         static HttpHelper()
         {
-            Version version = Assembly.GetExecutingAssembly().GetName().Version;
-            Assembly coreclr = Assembly.GetAssembly(typeof(object));
-            UserAgent = $"Mirai-CSharp/{version.ToString(version.MinorRevision > 0 ? 4 : 3)} CoreCLR/{coreclr.GetCustomAttribute<AssemblyFileVersionAttribute>().Version}";
+            Version version = Assembly.GetExecutingAssembly().GetName().Version!;
+            Assembly coreclr = Assembly.GetAssembly(typeof(object))!;
+            UserAgent = $"Mirai-CSharp/{version.ToString(version.MinorRevision > 0 ? 4 : 3)} CoreCLR/{coreclr.GetCustomAttribute<AssemblyFileVersionAttribute>()!.Version}";
         }
 
-        public static Task<WebResponse> HttpGetAsync(string url, double timeout = 10, string userAgent = null)
+        public static Task<WebResponse> HttpGetAsync(string url, double timeout = 10, string? userAgent = null)
         {
             HttpWebRequest request = WebRequest.CreateHttp(url);
             request.Timeout = (int)(timeout * 1000);
@@ -29,7 +29,7 @@ namespace Mirai_CSharp.Helpers
             return request.GetResponseAsync();
         }
 
-        public static Task<WebResponse> HttpPostAsync(string url, byte[] payload, double timeout = 10, string userAgent = null)
+        public static Task<WebResponse> HttpPostAsync(string url, byte[] payload, double timeout = 10, string? userAgent = null)
         {
             HttpWebRequest request = WebRequest.CreateHttp(url);
             request.Method = "POST";
@@ -39,12 +39,16 @@ namespace Mirai_CSharp.Helpers
                                                                // MemoryStream类下的异步方法都是调用对应的同步方法, 然后返回
                                                                // default(ValueTask) / Task.CompletedTask
             {
+#if NETSTANDARD2_0
+                stream.Write(payload, 0, payload.Length);
+#else
                 stream.Write(payload);
+#endif
             }
             return request.GetResponseAsync();
         }
 
-        public static async Task<WebResponse> HttpPostAsync(string url, HttpContent[] contents, double timeout = 10, string userAgent = null)
+        public static async Task<WebResponse> HttpPostAsync(string url, HttpContent[] contents, double timeout = 10, string? userAgent = null)
         {
             HttpWebRequest request = WebRequest.CreateHttp(url);
             request.Method = "POST";
@@ -64,7 +68,7 @@ namespace Mirai_CSharp.Helpers
             return await request.GetResponseAsync();
         }
 
-        public static async Task<string> GetStringAsync(this WebResponse response, Encoding encoding = null, bool disposeResponse = true)
+        public static async Task<string> GetStringAsync(this WebResponse response, Encoding? encoding = null, bool disposeResponse = true)
         {
             try
             {
@@ -80,7 +84,7 @@ namespace Mirai_CSharp.Helpers
                 }
             }
         }
-        public static async Task<string> GetStringAsync(this Task<WebResponse> responseTask, Encoding encoding = null)
+        public static async Task<string> GetStringAsync(this Task<WebResponse> responseTask, Encoding? encoding = null)
         {
             using WebResponse response = await responseTask.ConfigureAwait(false);
             using Stream stream = response.GetResponseStream();
@@ -114,7 +118,7 @@ namespace Mirai_CSharp.Helpers
         {
             return task.ContinueWith(t =>
             {
-                if (t.IsFaulted && t.Exception.InnerException is WebException e)
+                if (t.IsFaulted && t.Exception!.InnerException is WebException e && e.Response != null)
                 {
                     return Task.FromResult(e.Response);
                 }

--- a/Mirai-CSharp/Mirai-CSharp.csproj
+++ b/Mirai-CSharp/Mirai-CSharp.csproj
@@ -1,13 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;netcoreapp3.1;netstandard2.1;netstandard2.0</TargetFrameworks>
     <RootNamespace>Mirai_CSharp</RootNamespace>
     <OutputType>Library</OutputType>
     <NoWin32Manifest>true</NoWin32Manifest>
-    <Version>1.0.1.5</Version>
-    <AssemblyVersion>1.0.1.5</AssemblyVersion>
-    <FileVersion>1.0.1.5</FileVersion>
+    <Version>1.0.1.6</Version>
+    <AssemblyVersion>1.0.1.6</AssemblyVersion>
+    <FileVersion>1.0.1.6</FileVersion>
+    <Nullable>enable</Nullable>
+    <LangVersion>preview</LangVersion>
     <Authors>Executor</Authors>
     <Company>Executor</Company>
     <Copyright>Copyright © Executor 2020</Copyright>
@@ -15,7 +17,7 @@
     <PackageLicenseExpression>AGPL-3.0-or-later</PackageLicenseExpression>
     <PackageProjectUrl>https://github.com/Executor-Cheng/Mirai-CSharp</PackageProjectUrl>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
-    <RepositoryUrl>https://github.com/Executor-Cheng/Mirai-CSharp.git</RepositoryUrl>
+    <RepositoryUrl>https://github.com/Executor-Cheng/Mirai-CSharp</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
     <PackageReleaseNotes></PackageReleaseNotes>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -33,15 +35,25 @@
     <NoWarn>1701;1702;1591</NoWarn>
   </PropertyGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <Compile Remove="Plugin\Interfaces\**" />
+    <EmbeddedResource Remove="Plugin\Interfaces\**" />
+    <None Remove="Plugin\Interfaces\**" />
+  </ItemGroup>
+
   <ItemGroup>
     <None Remove="Mirai-CSharp.xml" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
     <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
+    <PackageReference Include="System.Drawing.Common" Version="5.0.0-preview.5.20278.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0'">
     <PackageReference Include="System.Text.Json" Version="4.7.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.7.1" />
   </ItemGroup>

--- a/Mirai-CSharp/Models/EventArgs/Bot/BotEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Bot/BotEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
 {
@@ -14,7 +15,11 @@ namespace Mirai_CSharp.Models
         long QQNumber { get; }
     }
 
-    public class BotEventArgs : IBotOnlineEventArgs, IBotPositiveOfflineEventArgs, IBotKickedOfflineEventArgs, IBotDroppedEventArgs, IBotReloginEventArgs
+    public class BotEventArgs : IBotOnlineEventArgs, 
+                                IBotPositiveOfflineEventArgs,
+                                IBotKickedOfflineEventArgs, 
+                                IBotDroppedEventArgs, 
+                                IBotReloginEventArgs
     {
         /// <summary>
         /// 机器人QQ号
@@ -22,14 +27,16 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("qq")]
         public long QQNumber { get; set; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotEventArgs()
         {
 
         }
 
-        public BotEventArgs(long qQNumber)
+        [Obsolete("此类不应由用户主动创建实例。")]
+        public BotEventArgs(long qqNumber)
         {
-            QQNumber = qQNumber;
+            QQNumber = qqNumber;
         }
     }
 

--- a/Mirai-CSharp/Models/EventArgs/CommandExecutedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/CommandExecutedEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 #pragma warning disable CA1819 // Properties should not return arrays
 namespace Mirai_CSharp.Models
@@ -47,15 +48,18 @@ namespace Mirai_CSharp.Models
     public class CommandExecutedEventArgs : ICommandExecutedEventArgs
     {
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
 
         [JsonPropertyName("args")]
-        public string[] Args { get; set; }
+        public string[] Args { get; set; } = null!;
 
         [JsonPropertyName("sender")]
         public long Sender { get; set; }
 
         [JsonPropertyName("group")]
         public long Group { get; set; }
+
+        [Obsolete("此类不应由用户主动创建实例。")]
+        public CommandExecutedEventArgs() { }
     }
 }

--- a/Mirai-CSharp/Models/EventArgs/CommonMessageEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/CommonMessageEventArgs.cs
@@ -24,7 +24,7 @@ namespace Mirai_CSharp.Models
         /// </summary>
         [JsonConverter(typeof(IMessageBaseArrayConverter))]
         [JsonPropertyName("messageChain")]
-        public IMessageBase[] Chain { get; set; }
+        public IMessageBase[] Chain { get; set; } = null!;
 
         protected CommonMessageEventArgs() { }
 

--- a/Mirai-CSharp/Models/EventArgs/DisconnectedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/DisconnectedEventArgs.cs
@@ -16,13 +16,15 @@ namespace Mirai_CSharp.Models
 
     public class DisconnectedEventArgs : IDisconnectedEventArgs
     {
-        public Exception Exception { get; set; }
+        public Exception Exception { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public DisconnectedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public DisconnectedEventArgs(Exception exception)
         {
             Exception = exception;

--- a/Mirai-CSharp/Models/EventArgs/Friend/FriendMessageEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Friend/FriendMessageEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using Mirai_CSharp.Utility.JsonConverters;
+using System;
 using System.Collections.Generic;
 using System.Text.Json.Serialization;
 
@@ -18,16 +19,18 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, IFriendInfo>))]
         [JsonPropertyName("sender")]
-        public IFriendInfo Sender { get; set; }
+        public IFriendInfo Sender { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public FriendMessageEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public FriendMessageEventArgs(IMessageBase[] chain, IFriendInfo sender) : base(chain)
         {
             Sender = sender;
         }
 
         public override string ToString()
-            => $"{Sender.Name}({Sender.Id}) -> {string.Join("", (IEnumerable<MessageBase>)Chain)}";
+            => $"{Sender.Name}({Sender.Id}) -> {string.Join("", (IEnumerable<Messages>)Chain)}";
     }
 }

--- a/Mirai-CSharp/Models/EventArgs/Friend/FriendMessageRevokedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Friend/FriendMessageRevokedEventArgs.cs
@@ -23,8 +23,10 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("operator")]
         public long Operator { get; set; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public FriendMessageRevokedEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public FriendMessageRevokedEventArgs(long @operator, long senderId, int messageId, DateTime sentTime) : base(senderId, messageId, sentTime)
         {
             Operator = @operator;

--- a/Mirai-CSharp/Models/EventArgs/Friend/NewFriendApplyEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Friend/NewFriendApplyEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Mirai_CSharp.Models
+﻿using System;
+
+namespace Mirai_CSharp.Models
 {
     /// <summary>
     /// 提供好友申请相关信息的接口。继承自 <see cref="INewApplyEventArgs"/>
@@ -10,11 +12,13 @@
 
     public class NewFriendApplyEventArgs : NewApplyEventArgs, INewFriendApplyEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public NewFriendApplyEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public NewFriendApplyEventArgs(long eventId, long fromGroup, long fromQQ, string nickName) : base(eventId, fromGroup, fromQQ, nickName)
         {
 

--- a/Mirai-CSharp/Models/EventArgs/Group/CommonGroupApplyEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/CommonGroupApplyEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
 {
@@ -16,13 +17,15 @@ namespace Mirai_CSharp.Models
                                        IBotInvitedJoinGroupEventArgs
     {
         [JsonPropertyName("groupName")]
-        public string FromGroupName { get; set; }
+        public string FromGroupName { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public CommonGroupApplyEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public CommonGroupApplyEventArgs(string fromGroupName, long eventId, long fromGroup, long fromQQ, string nickName) : base(eventId, fromGroup, fromQQ, nickName)
         {
             FromGroupName = fromGroupName;

--- a/Mirai-CSharp/Models/EventArgs/Group/GroupEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/GroupEventArgs.cs
@@ -1,4 +1,5 @@
 ﻿using Mirai_CSharp.Utility.JsonConverters;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
@@ -20,10 +21,12 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
         [JsonPropertyName("group")]
-        public IGroupInfo Group { get; set; }
+        public IGroupInfo Group { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupEventArgs(GroupInfo group)
         {
             Group = group;
@@ -46,10 +49,12 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("member")]
-        public IGroupMemberInfo Member { get; set; }
+        public IGroupMemberInfo Member { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public MemberEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public MemberEventArgs(IGroupMemberInfo member)
         {
             Member = member;
@@ -70,10 +75,12 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("operator")]
-        public virtual IGroupMemberInfo Operator { get; set; }
+        public virtual IGroupMemberInfo Operator { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public OperatorEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public OperatorEventArgs(IGroupMemberInfo @operator)
         {
             Operator = @operator;
@@ -92,10 +99,12 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
         [JsonPropertyName("group")]
-        public IGroupInfo Group { get; set; }
+        public IGroupInfo Group { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupOperatingEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupOperatingEventArgs(IGroupInfo group, IGroupMemberInfo @operator) : base(@operator)
         {
             Group = group;
@@ -115,10 +124,12 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("member")]
-        public IGroupMemberInfo Member { get; set; }
+        public IGroupMemberInfo Member { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public MemberOperatingEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public MemberOperatingEventArgs(IGroupMemberInfo member, IGroupMemberInfo @operator) : base(@operator)
         {
             Member = member;

--- a/Mirai-CSharp/Models/EventArgs/Group/GroupMessageEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/GroupMessageEventArgs.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 
 namespace Mirai_CSharp.Models
 {
@@ -12,17 +13,19 @@ namespace Mirai_CSharp.Models
 
     public class GroupMessageEventArgs : GroupMessageBaseEventArgs, IGroupMessageEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMessageEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMessageEventArgs(IMessageBase[] chain, IGroupMemberInfo sender) : base(chain, sender)
         {
 
         }
 
         public override string ToString()
-            => $"[{Sender.Group.Name}({Sender.Group.Id})] {Sender.Name}({Sender.Id}) -> {string.Join("", (IEnumerable<MessageBase>)Chain)}";
+            => $"[{Sender.Group.Name}({Sender.Group.Id})] {Sender.Name}({Sender.Id}) -> {string.Join("", (IEnumerable<Messages>)Chain)}";
     }
 }

--- a/Mirai-CSharp/Models/EventArgs/Group/GroupMessageRevokedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/GroupMessageRevokedEventArgs.cs
@@ -19,16 +19,18 @@ namespace Mirai_CSharp.Models
         /// </summary>
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
         [JsonPropertyName("group")]
-        public IGroupInfo Group { get; set; }
+        public IGroupInfo Group { get; set; } = null!;
         /// <summary>
         /// 进行撤回操作的用户信息
         /// </summary>
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("operator")]
-        public IGroupMemberInfo Operator { get; set; }
+        public IGroupMemberInfo Operator { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMessageRevokedEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMessageRevokedEventArgs(IGroupInfo group, IGroupMemberInfo @operator, long senderId, int messageId, DateTime sentTime) : base(senderId, messageId, sentTime)
         {
             Group = group;

--- a/Mirai-CSharp/Models/EventArgs/Group/GroupMuteEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/GroupMuteEventArgs.cs
@@ -25,11 +25,13 @@ namespace Mirai_CSharp.Models
 
     public class BotUnmutedEventArgs : OperatorEventArgs, IBotUnmutedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotUnmutedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotUnmutedEventArgs(GroupMemberInfo @operator) : base(@operator)
         {
 
@@ -50,8 +52,10 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("durationSeconds")]
         public TimeSpan Duration { get; set; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotMutedEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotMutedEventArgs(TimeSpan duration, GroupMemberInfo @operator) : base(@operator)
         {
             Duration = duration;
@@ -68,11 +72,13 @@ namespace Mirai_CSharp.Models
 
     public class GroupMemberUnmutedEventArgs : MemberOperatingEventArgs, IGroupMemberUnmutedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberUnmutedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberUnmutedEventArgs(IGroupMemberInfo member, IGroupMemberInfo @operator) : base(member, @operator)
         {
 
@@ -93,11 +99,13 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("durationSeconds")]
         public TimeSpan Duration { get; set; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberMutedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberMutedEventArgs(TimeSpan duration, IGroupMemberInfo member, IGroupMemberInfo @operator) : base(member, @operator)
         {
             Duration = duration;

--- a/Mirai-CSharp/Models/EventArgs/Group/PropertyChangedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/PropertyChangedEventArgs.cs
@@ -28,12 +28,12 @@ namespace Mirai_CSharp.Models
         /// 修改前
         /// </summary>
         [JsonPropertyName("origin")]
-        public virtual TProperty Origin { get; set; }
+        public virtual TProperty Origin { get; set; } = default!;
         /// <summary>
         /// 修改后
         /// </summary>
         [JsonPropertyName("current")]
-        public virtual TProperty Current { get; set; }
+        public virtual TProperty Current { get; set; } = default!;
 
         protected PropertyChangedEventArgs() { }
 
@@ -53,14 +53,27 @@ namespace Mirai_CSharp.Models
     /// <typeparam name="TProperty">属性类型, 必须为枚举类型</typeparam>
     public interface IEnumPropertyChangedEventArgs<TProperty> : IPropertyChangedEventArgs<TProperty> where TProperty : Enum
     {
+#if NETSTANDARD2_0
+        /// <inheritdoc/>
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("origin")]
+        new TProperty Origin { get; }
+
+        /// <inheritdoc/>
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("current")]
+        new TProperty Current { get; }
+#else
         /// <inheritdoc/>
         [JsonConverter(typeof(JsonStringEnumConverter))]
         [JsonPropertyName("origin")]
         abstract TProperty IPropertyChangedEventArgs<TProperty>.Origin { get; }
+
         /// <inheritdoc/>
         [JsonConverter(typeof(JsonStringEnumConverter))]
         [JsonPropertyName("current")]
         abstract TProperty IPropertyChangedEventArgs<TProperty>.Current { get; }
+#endif
     }
 
     public abstract class EnumPropertyChangedEventArgs<TProperty> : PropertyChangedEventArgs<TProperty> where TProperty : Enum
@@ -100,7 +113,7 @@ namespace Mirai_CSharp.Models
         /// </summary>
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
         [JsonPropertyName("group")]
-        public IGroupInfo Group { get; set; }
+        public IGroupInfo Group { get; set; } = null!;
 
         protected BotGroupPropertyChangedEventArgs() { }
 
@@ -132,15 +145,26 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("current")]
         public override TProperty Current { get => base.Current; set => base.Current = value; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotGroupEnumPropertyChangedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotGroupEnumPropertyChangedEventArgs(IGroupInfo group, TProperty origin, TProperty current) : base(group, origin, current)
         {
 
         }
+#if NETSTANDARD2_0
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("origin")]
+        TProperty IEnumPropertyChangedEventArgs<TProperty>.Origin => base.Origin;
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("current")]
+        TProperty IEnumPropertyChangedEventArgs<TProperty>.Current => base.Current;
+#endif
     }
 
     /// <summary>
@@ -159,12 +183,14 @@ namespace Mirai_CSharp.Models
         /// </summary>
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("operator")]
-        public IGroupMemberInfo Operator { get; set; }
+        public IGroupMemberInfo Operator { get; set; } = null!;
 
         /*protected*/
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupPropertyChangedEventArgs() { }
 
         /*protected*/
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupPropertyChangedEventArgs(IGroupInfo group, IGroupMemberInfo @operator, TProperty origin, TProperty current) : base(group, origin, current)
         {
             Operator = @operator;
@@ -272,12 +298,14 @@ namespace Mirai_CSharp.Models
         /// </summary>
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("member")]
-        public IGroupMemberInfo Member { get; set; }
+        public IGroupMemberInfo Member { get; set; } = null!;
 
         /*protected*/
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberPropertyChangedEventArgs() { }
 
         /*protected*/
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberPropertyChangedEventArgs(IGroupMemberInfo member, TProperty origin, TProperty current) : base(origin, current)
         {
             Member = member;
@@ -319,11 +347,22 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("current")]
         public override TProperty Current { get => base.Current; set => base.Current = value; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberEnumPropertyChangedEventArgs() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberEnumPropertyChangedEventArgs(IGroupMemberInfo member, TProperty origin, TProperty current) : base(member, origin, current)
         {
 
         }
+#if NETSTANDARD2_0
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("origin")]
+        TProperty IEnumPropertyChangedEventArgs<TProperty>.Origin => base.Origin;
+
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("current")]
+        TProperty IEnumPropertyChangedEventArgs<TProperty>.Current => base.Current;
+#endif
     } // 不能继承多个类, 只能每次都啰嗦两次override
 }

--- a/Mirai-CSharp/Models/EventArgs/Group/Specialized/BotGroupPermissionChangedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/Specialized/BotGroupPermissionChangedEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Mirai_CSharp.Models
+﻿using System;
+
+namespace Mirai_CSharp.Models
 {
     /// <summary>
     /// 提供Bot在群里的权限被改变相关信息的接口。继承自 <see cref="IBotGroupPropertyChangedEventArgs{TProperty}"/>
@@ -11,11 +13,13 @@
     public class BotGroupPermissionChangedEventArgs : BotGroupEnumPropertyChangedEventArgs<GroupPermission>,
                                                       IBotGroupPermissionChangedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotGroupPermissionChangedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public BotGroupPermissionChangedEventArgs(IGroupInfo group, GroupPermission origin, GroupPermission current) : base(group, origin, current)
         {
 

--- a/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupBoolPropertyChangedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupBoolPropertyChangedEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Mirai_CSharp.Models
+﻿using System;
+
+namespace Mirai_CSharp.Models
 {
     /// <summary>
     /// 提供全员禁言设置被改变相关信息的接口。继承自 <see cref="IGroupPropertyChangedEventArgs{TProperty}"/>
@@ -38,11 +40,13 @@
                                                      IGroupConfessTalkChangedEventArgs,
                                                      IGroupMemberInviteChangedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupBoolPropertyChangedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupBoolPropertyChangedEventArgs(IGroupInfo group, IGroupMemberInfo @operator, bool origin, bool current) : base(group, @operator, origin, current)
         {
 

--- a/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupMemberPermissionChangedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupMemberPermissionChangedEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Mirai_CSharp.Models
+﻿using System;
+
+namespace Mirai_CSharp.Models
 {
     /// <summary>
     /// 提供成员权限改变相关信息的接口。继承自 <see cref="IGroupMemberEnumPropertyChangedEventArgs{TProperty}"/>
@@ -11,11 +13,13 @@
     public class GroupMemberPermissionChangedEventArgs : GroupMemberEnumPropertyChangedEventArgs<GroupPermission>,
                                                          IGroupMemberPermissionChangedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberPermissionChangedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberPermissionChangedEventArgs(IGroupMemberInfo member, GroupPermission origin, GroupPermission current) : base(member, origin, current)
         {
 

--- a/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupMemberStringPropertyChangedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupMemberStringPropertyChangedEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Mirai_CSharp.Models
+﻿using System;
+
+namespace Mirai_CSharp.Models
 {
     /// <summary>
     /// 提供群名片改动相关信息的接口。继承自 <see cref="IGroupMemberPropertyChangedEventArgs{TProperty}"/>
@@ -20,11 +22,13 @@
                                                              IGroupMemberCardChangedEventArgs,
                                                              IGroupMemberSpecialTitleChangedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberStringPropertyChangedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberStringPropertyChangedEventArgs(IGroupMemberInfo member, string origin, string current) : base(member, origin, current)
         {
 

--- a/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupStringPropertyChangedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/Specialized/GroupStringPropertyChangedEventArgs.cs
@@ -1,4 +1,6 @@
-﻿namespace Mirai_CSharp.Models
+﻿using System;
+
+namespace Mirai_CSharp.Models
 {
     /// <summary>
     /// 提供群名称改变相关信息的接口。继承自 <see cref="IGroupPropertyChangedEventArgs{TProperty}"/>
@@ -21,11 +23,13 @@
                                                        IGroupNameChangedEventArgs, 
                                                        IGroupEntranceAnnouncementChangedEventArgs
     {
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupStringPropertyChangedEventArgs()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupStringPropertyChangedEventArgs(IGroupInfo group, IGroupMemberInfo @operator, string origin, string current) : base(group, @operator, origin, current)
         {
 

--- a/Mirai-CSharp/Models/EventArgs/GroupMessageBaseEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/GroupMessageBaseEventArgs.cs
@@ -18,7 +18,7 @@ namespace Mirai_CSharp.Models
     {
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
         [JsonPropertyName("sender")]
-        public IGroupMemberInfo Sender { get; set; }
+        public IGroupMemberInfo Sender { get; set; } = null!;
 
         protected GroupMessageBaseEventArgs() { }
 
@@ -28,6 +28,6 @@ namespace Mirai_CSharp.Models
         }
 
         public override string ToString()
-            => $"[{Sender.Group.Name}({Sender.Group.Id})] {Sender.Name}({Sender.Id}) -> {string.Join("", (IEnumerable<MessageBase>)Chain)}";
+            => $"[{Sender.Group.Name}({Sender.Group.Id})] {Sender.Name}({Sender.Id}) -> {string.Join("", (IEnumerable<Messages>)Chain)}";
     }
 }

--- a/Mirai-CSharp/Models/EventArgs/NewApplyEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/NewApplyEventArgs.cs
@@ -38,7 +38,7 @@ namespace Mirai_CSharp.Models
         public long FromQQ { get; set; }
 
         [JsonPropertyName("nick")]
-        public string NickName { get; set; }
+        public string NickName { get; set; } = null!;
 
         protected NewApplyEventArgs() { }
 

--- a/Mirai-CSharp/Models/EventArgs/Temp/ITempMessageEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Temp/ITempMessageEventArgs.cs
@@ -23,6 +23,6 @@ namespace Mirai_CSharp.Models
         }
 
         public override string ToString()
-            => $"[{Sender.Group.Name}({Sender.Group.Id})] {Sender.Name}(Temp {Sender.Id}) -> {string.Join("", (IEnumerable<MessageBase>)Chain)}";
+            => $"[{Sender.Group.Name}({Sender.Group.Id})] {Sender.Name}(Temp {Sender.Id}) -> {string.Join("", (IEnumerable<Messages>)Chain)}";
     }
 }

--- a/Mirai-CSharp/Models/FriendInfo.cs
+++ b/Mirai-CSharp/Models/FriendInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
 {
@@ -7,11 +8,19 @@ namespace Mirai_CSharp.Models
     /// </summary>
     public interface IFriendInfo : IBaseInfo
     {
+#if NETSTANDARD2_0
+        /// <summary>
+        /// 好友昵称
+        /// </summary>
+        [JsonPropertyName("nickname")]
+        new string Name { get; }
+#else
         /// <summary>
         /// 好友昵称
         /// </summary>
         [JsonPropertyName("nickname")]
         abstract string IBaseInfo.Name { get; }
+#endif
         /// <summary>
         /// 好友备注
         /// </summary>
@@ -30,16 +39,22 @@ namespace Mirai_CSharp.Models
         /// 好友备注
         /// </summary>
         [JsonPropertyName("remark")]
-        public string Remark { get; set; }
+        public string Remark { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public FriendInfo()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public FriendInfo(long id, string name, string remark) : base(id, name)
         {
             Remark = remark;
         }
+#if NETSTANDARD2_0
+        [JsonPropertyName("nickname")]
+        string IFriendInfo.Name => base.Name;
+#endif
     }
 }

--- a/Mirai-CSharp/Models/GroupConfig.cs
+++ b/Mirai-CSharp/Models/GroupConfig.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
 {
@@ -45,12 +46,12 @@ namespace Mirai_CSharp.Models
         /// 群名
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         /// <summary>
         /// 群公告
         /// </summary>
         [JsonPropertyName("announcement")]
-        public string Announcement { get; set; }
+        public string Announcement { get; set; } = null!;
         /// <summary>
         /// 是否允许坦白说
         /// </summary>
@@ -72,6 +73,7 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("anonymousChat")]
         public bool? AnonymousChat { get; set; }
 
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
         public GroupConfig()
         {
 

--- a/Mirai-CSharp/Models/GroupInfo.cs
+++ b/Mirai-CSharp/Models/GroupInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
 {
@@ -30,7 +31,7 @@ namespace Mirai_CSharp.Models
         /// 昵称/群名
         /// </summary>
         [JsonPropertyName("name")]
-        public virtual string Name { get; set; }
+        public virtual string Name { get; set; } = null!;
 
         protected BaseInfo()
         {
@@ -66,8 +67,10 @@ namespace Mirai_CSharp.Models
         [JsonPropertyName("permission")]
         public virtual GroupPermission Permission { get; set; }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupInfo() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupInfo(long id, string name, GroupPermission permission)
         {
             Id = id;

--- a/Mirai-CSharp/Models/GroupMemberCardInfo.cs
+++ b/Mirai-CSharp/Models/GroupMemberCardInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Text.Json.Serialization;
+﻿using System;
+using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
 {
@@ -25,18 +26,20 @@ namespace Mirai_CSharp.Models
         /// 群名片
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; set; }
+        public string Name { get; set; } = null!;
         /// <summary>
         /// 专属头衔
         /// </summary>
         [JsonPropertyName("specialTitle")]
-        public string SpecialTitle { get; set; }
+        public string SpecialTitle { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberCardInfo()
         {
 
         }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberCardInfo(string name, string specialTitle)
         {
             Name = name;

--- a/Mirai-CSharp/Models/GroupMemberInfo.cs
+++ b/Mirai-CSharp/Models/GroupMemberInfo.cs
@@ -1,4 +1,5 @@
 ﻿using Mirai_CSharp.Utility.JsonConverters;
+using System;
 using System.Text.Json.Serialization;
 
 namespace Mirai_CSharp.Models
@@ -8,11 +9,19 @@ namespace Mirai_CSharp.Models
     /// </summary>
     public interface IGroupMemberInfo : IGroupInfo
     {
+#if NETSTANDARD2_0
+        /// <summary>
+        /// 成员昵称
+        /// </summary>
+        [JsonPropertyName("memberName")]
+        new string Name { get; }
+#else
         /// <summary>
         /// 成员昵称
         /// </summary>
         [JsonPropertyName("memberName")]
         abstract string IBaseInfo.Name { get; }
+#endif
 
         /// <summary>
         /// 机器人所在群的信息
@@ -34,13 +43,19 @@ namespace Mirai_CSharp.Models
         /// </summary>
         [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
         [JsonPropertyName("group")]
-        public IGroupInfo Group { get; set; }
+        public IGroupInfo Group { get; set; } = null!;
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberInfo() { }
 
+        [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberInfo(IGroupInfo args, long id, string name, GroupPermission permission) : base(id, name, permission)
         {
             Group = args;
         }
+#if NETSTANDARD2_0
+        [JsonPropertyName("memberName")]
+        string IBaseInfo.Name => base.Name;
+#endif
     }
 }

--- a/Mirai-CSharp/Models/Messages.cs~HEAD
+++ b/Mirai-CSharp/Models/Messages.cs~HEAD
@@ -1,0 +1,459 @@
+﻿using Mirai_CSharp.Utility.JsonConverters;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+#pragma warning disable CA1819 // Properties should not return arrays
+#pragma warning disable CS0618 // 此警告是用户专用的
+namespace Mirai_CSharp.Models
+{
+    public interface IMessageBase
+    {
+        /// <summary>
+        /// 消息类型。供api或反序列化使用
+        /// </summary>
+        [JsonPropertyName("type")]
+        string Type { get; }
+    }
+
+    // -- 构成消息链的类 (为了方便Deserialize, 这些子类都不是readonly的。将来JsonSerializer会像Json.NET一样去寻找对应的有参构造, 届时再改为readonly。) --
+    public abstract class Messages : IMessageBase
+    {
+        /// <summary>
+        /// 消息类型。供api或反序列化使用
+        /// </summary>
+        [JsonPropertyName("type")]
+        public string Type { get; }
+
+        protected Messages(string type)
+        {
+            Type = type;
+        }
+    }
+    /// <summary>
+    /// 表示消息的基本信息
+    /// </summary>
+    public class SourceMessage : Messages
+    {
+        public const string MsgType = "Source";
+        /// <summary>
+        /// 消息的识别号, 用于引用回复或撤回
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+        /// <summary>
+        /// 消息时间
+        /// </summary>
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("time")]
+        public DateTime Time { get; set; }
+
+        [Obsolete("此类不应由用户主动创建实例。")]
+        public SourceMessage() : base(MsgType) { }
+
+        [Obsolete("此类不应由用户主动创建实例。")]
+        public SourceMessage(int id, DateTime time) : this()
+        {
+            Id = id;
+            Time = time;
+        }
+
+        public override string ToString()
+            => $"[mirai:source:{Id}]";
+    }
+    /// <summary>
+    /// 表示引用消息
+    /// </summary>
+    public class QuoteMessage : Messages
+    {
+        public const string MsgType = "Quote";
+        /// <summary>
+        /// 被引用回复的原消息的messageId
+        /// </summary>
+        [JsonPropertyName("id")]
+        public int Id { get; set; }
+        /// <summary>
+        /// 被引用回复的原消息所接收的群号，当为好友消息时为0
+        /// </summary>
+        [JsonPropertyName("groupId")]
+        public long GroupId { get; set; }
+        /// <summary>
+        /// 被引用回复的原消息的发送者的QQ号
+        /// </summary>
+        [JsonPropertyName("senderId")]
+        public long SenderId { get; set; }
+        /// <summary>
+        /// 被引用回复的原消息的接收者者的QQ号（或群号）
+        /// </summary>
+        [JsonPropertyName("targetId")]
+        public long TargetId { get; set; }
+        /// <summary>
+        /// 被引用回复的原消息的消息链数组
+        /// </summary>
+        [JsonConverter(typeof(IMessageBaseArrayConverter))]
+        [JsonPropertyName("origin")]
+<<<<<<< HEAD:Mirai-CSharp/Models/Messages.cs
+        public IMessageBase[] OriginChain { get; set; } = null!; // 只在反序列化时进行赋值, 故不为null
+=======
+        public MessageBase[] OriginChain { get; set; }
+>>>>>>> parent of 14283c1... v1.0.1.5: 修复了收到引用回复消息时, 由于 QuoteMessage.OriginChain 类型错误导致无法反序列化断开ws连接的问题。:Mirai-CSharp/Models/MessageBase.cs
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public QuoteMessage() : base(MsgType) { }
+
+        public QuoteMessage(int id, long groupId, long senderId, long targetId, MessageBase[] originChain) : this()
+        {
+            Id = id;
+            GroupId = groupId;
+            SenderId = senderId;
+            TargetId = targetId;
+            OriginChain = originChain;
+        }
+
+        public override string ToString()
+            => $"[mirai:quote:{Id}]";
+    }
+    /// <summary>
+    /// 表示文字消息
+    /// </summary>
+    public class PlainMessage : Messages
+    {
+        public const string MsgType = "Plain";
+        /// <summary>
+        /// 文字消息
+        /// </summary>
+        [JsonPropertyName("text")]
+        public string Message { get; set; } = null!;
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public PlainMessage() : base(MsgType) { }
+
+        public PlainMessage(string message) : this()
+        {
+            Message = message;
+        }
+
+        public override string ToString()
+            => Message;
+    }
+    /// <summary>
+    /// 图片消息基类
+    /// </summary>
+    public abstract class CommonImageMessage : Messages
+    {
+        /// <summary>
+        /// 图片的imageId，群图片与好友图片格式不同。不为空时将忽略url属性
+        /// </summary>
+        [JsonPropertyName("imageId")]
+        public string? ImageId { get; set; }
+        /// <summary>
+        /// 图片的URL，发送时可作网络图片的链接；接收时为腾讯图片服务器的链接，可用于图片下载
+        /// </summary>
+        [JsonPropertyName("url")]
+        public string? Url { get; set; }
+        /// <summary>
+        /// 图片的路径，发送本地图片，相对路径于 plugins/MiraiAPIHTTP/images
+        /// </summary>
+        [JsonPropertyName("path")]
+        public string? Path { get; set; }
+
+        protected CommonImageMessage(string type, string? imageId, string? url, string? path) : base(type)
+        {
+            ImageId = imageId;
+            Url = url;
+            Path = path;
+        }
+    }
+    /// <summary>
+    /// 表示图片消息
+    /// </summary>
+    public class ImageMessage : CommonImageMessage
+    {
+        public const string MsgType = "Image";
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public ImageMessage() : this(null, null, null) { }
+
+        public ImageMessage(string? imageId, string? url, string? path) : base(MsgType, imageId, url, path)
+        {
+        }
+
+        public override string ToString()
+            => $"[mirai:image:{ImageId}]";
+    }
+    /// <summary>
+    /// 表示闪照消息
+    /// </summary>
+    public class FlashImageMessage : CommonImageMessage
+    {
+        public const string MsgType = "FlashImage";
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public FlashImageMessage() : this(null, null, null) { }
+
+        public FlashImageMessage(string? imageId, string? url, string? path) : base(MsgType, imageId, url, path)
+        {
+        }
+
+        public override string ToString()
+            => $"[mirai:flashimage:{ImageId}]"; // 不同于源码实现。原同ImageMessage
+    }
+    /// <summary>
+    /// 表示 @特定对象 消息
+    /// </summary>
+    public class AtMessage : Messages
+    {
+        public const string MsgType = "At";
+        /// <summary>
+        /// 被@的群员QQ号
+        /// </summary>
+        [JsonPropertyName("target")]
+        public long Target { get; set; }
+        /// <summary>
+        /// At时显示的文字，发送消息时无效，自动使用群名片
+        /// </summary>
+        [JsonPropertyName("display")]
+        public string Display { get; set; } = null!; // 由反序列化赋值
+
+        [Obsolete("请使用AtMessage(long)构造方法初始化本类实例。")]
+        public AtMessage() : base(MsgType) { }
+
+        public AtMessage(long target) : this()
+        {
+            Target = target;
+        }
+
+        [Obsolete("请使用AtMessage(long)构造方法初始化本类实例。")]
+        public AtMessage(long target, string display) : this(target)
+        {
+            Display = display;
+        }
+
+        public override string ToString()
+            => $"[mirai:at:{Target}]";
+    }
+    /// <summary>
+    /// 表示 @全体成员 消息
+    /// </summary>
+    public class AtAllMessage : Messages
+    {
+        public const string MsgType = "AtAll";
+
+        public AtAllMessage() : base(MsgType)
+        {
+
+        }
+
+        public override string ToString()
+            => "[mirai:atall]";
+    }
+    /// <summary>
+    /// 表示一个QQ表情
+    /// </summary>
+    public class FaceMessage : Messages
+    {
+        public const string MsgType = "Face";
+        /// <summary>
+        /// QQ表情编号，可选，优先高于name
+        /// </summary>
+        /// <remarks>
+        /// 编号详见 <a href="https://github.com/mamoe/mirai/blob/master/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/message/data/Face.kt#L41"/>
+        /// </remarks>
+        [JsonPropertyName("faceId")]
+        public int Id { get; set; }
+        /// <summary>
+        /// QQ表情拼音，可选
+        /// </summary>
+        [JsonPropertyName("name")]
+        public string? Name { get; set; }
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public FaceMessage() : base(MsgType) { }
+
+        public FaceMessage(int id, string? name) : this()
+        {
+            Id = id;
+            Name = name;
+        }
+
+        public override string ToString()
+            => $"[mirai:face:{Id}]";
+    }
+    /// <summary>
+    /// 表示xml消息
+    /// </summary>
+    public class XmlMessage : Messages
+    {
+        public const string MsgType = "Xml";
+
+        [JsonPropertyName("xml")]
+        public string Xml { get; set; } = null!;
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public XmlMessage() : base(MsgType) { }
+
+        public XmlMessage(string xml) : this()
+        {
+            Xml = xml;
+        }
+
+        public override string ToString()
+            => $"[mirai:service:60,{Xml}]"; // Xml的ServiceId=60, https://github.com/mamoe/mirai/blob/master/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/message/data/RichMessage.kt#L109
+    }
+    /// <summary>
+    /// 表示Json消息
+    /// </summary>
+    public class JsonMessage : Messages
+    {
+        public const string MsgType = "Json";
+
+        [JsonPropertyName("json")]
+        public string Json { get; set; } = null!;
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public JsonMessage() : base(MsgType) { }
+
+        public JsonMessage(string json) : this()
+        {
+            Json = json;
+        }
+
+        public override string ToString()
+            => $"[mirai:service:1,{Json}]"; // Json的ServiceId=1, https://github.com/mamoe/mirai/blob/master/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/message/data/RichMessage.kt#L109
+    }
+    /// <summary>
+    /// 表示App消息
+    /// </summary>
+    public class AppMessage : Messages
+    {
+        public const string MsgType = "App";
+        /// <summary>
+        /// 消息内容
+        /// </summary>
+        [JsonPropertyName("content")]
+        public string Content { get; set; } = null!;
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public AppMessage() : base(MsgType) { }
+
+        public AppMessage(string content) : this()
+        {
+            Content = content;
+        }
+
+        public override string ToString()
+            => $"[mirai:app:{Content}]";
+    }
+    /// <summary>
+    /// 表示戳一戳消息
+    /// </summary>
+    public class PokeMessage : Messages
+    {
+        public const string MsgType = "Poke";
+        /// <summary>
+        /// 戳一戳的类型。
+        /// </summary>
+        /// <remarks>
+        /// SVIP的Poke带Id, <see langword="enum"/> 无法表示两个值, 不写。
+        /// 详见 <a href="https://github.com/mamoe/mirai/blob/8ca4357eb834f3c284deb68a6dd25d5c59957a82/mirai-core/src/commonMain/kotlin/net.mamoe.mirai/message/data/HummerMessage.kt#L56"/>
+        /// </remarks>
+        public enum PokeType
+        {
+            /// <summary>
+            /// 戳一戳
+            /// </summary>
+            Poke = 1,
+            /// <summary>
+            /// 比心
+            /// </summary>
+            ShowLove,
+            /// <summary>
+            /// 点赞
+            /// </summary>
+            Like,
+            /// <summary>
+            /// 心碎
+            /// </summary>
+            Heartbroken,
+            /// <summary>
+            /// 666
+            /// </summary>
+            SixSixSix,
+            /// <summary>
+            /// 放大招
+            /// </summary>
+            FangDaZhao,
+        }
+        /// <summary>
+        /// 戳一戳类型
+        /// </summary>
+        [JsonConverter(typeof(JsonStringEnumConverter))]
+        [JsonPropertyName("name")]
+        public PokeType Name { get; set; }
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public PokeMessage() : base(MsgType) { }
+
+        public PokeMessage(PokeType name) : this()
+        {
+            Name = name;
+        }
+
+        public override string ToString()
+            => $"[mirai:poke:{(int)Name},-1]"; // id在PokeType∈[1,6]时固定为-1
+    }
+
+    /// <summary>
+    /// 表示语音消息。
+    /// </summary>
+    /// <remarks>
+    /// 提前实现。目前mirai-api-http v1.7.1暂不支持。
+    /// </remarks>
+    public class VoiceMessage : Messages
+    {
+        public const string MsgType = "Voice";
+        /// <summary>
+        /// 语音文件名
+        /// </summary>
+        [JsonPropertyName("fileName")]
+        public string FileName { get; set; } = null!;
+        
+        [JsonPropertyName("md5")]
+        public string Md5 { get; set; } = null!;
+        /// <summary>
+        /// 用于下载语音的Url
+        /// </summary>
+        [JsonPropertyName("url")]
+        public string Url { get; set; } = null!;
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public VoiceMessage() : base(MsgType) { }
+
+        public VoiceMessage(string fileName, string md5, string url) : this()
+        {
+            FileName = fileName;
+            Md5 = md5;
+            Url = url;
+        }
+    }
+
+    /// <summary>
+    /// 表示未知消息
+    /// </summary>
+    public class UnknownMessage : Messages
+    {
+        public const string MsgType = "Unknown";
+        /// <summary>
+        /// 消息内容。如有需要请自行解析
+        /// </summary>
+        public JsonElement Data { get; set; }
+
+        [Obsolete("请使用带参数的构造方法初始化本类实例。")]
+        public UnknownMessage() : base(MsgType) { }
+
+        public UnknownMessage(JsonElement data) : this()
+        {
+            Data = data;
+        }
+    }
+}

--- a/Mirai-CSharp/Session/MiraiHttpSession.Application.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Application.cs
@@ -16,17 +16,17 @@ namespace Mirai_CSharp
         /// <param name="message">附加信息</param>
         public Task HandleNewFriendApplyAsync(IApplyResponseArgs args, FriendApplyAction action, string message = "")
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 eventId = args.EventId,
                 fromId = args.FromQQ,
                 groupId = args.FromGroup,
                 operate = (int)action,
                 message
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/resp/newFriendRequestEvent", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/resp/newFriendRequestEvent", payload, session.Token);
         }
         /// <summary>
         /// 异步处理加群请求或Bot受邀入群请求
@@ -42,17 +42,17 @@ namespace Mirai_CSharp
         /// <param name="message">附加信息</param>
         public Task HandleGroupApplyAsync(IApplyResponseArgs args, GroupApplyActions action, string message = "")
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 eventId = args.EventId,
                 fromId = args.FromQQ,
                 groupId = args.FromGroup,
                 operate = (int)action,
                 message
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/resp/memberJoinRequestEvent", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/resp/memberJoinRequestEvent", payload, session.Token);
         }
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Authentication.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Authentication.cs
@@ -30,7 +30,7 @@ namespace Mirai_CSharp
         /// 异步连接到mirai-api-http。
         /// </summary>
         /// <remarks>
-        /// 此方法不是线程安全的。
+        /// 此方法线程安全。但是在连接过程中, 如果尝试多次调用, 除了第一次以后的所有调用都将立即返回。
         /// </remarks>
         /// <exception cref="BotNotFoundException"/>
         /// <exception cref="InvalidAuthKeyException"/>
@@ -40,39 +40,38 @@ namespace Mirai_CSharp
         public async Task ConnectAsync(MiraiHttpSessionOptions options, long qqNumber, bool listenCommand)
         {
             CheckDisposed();
-            if (this.Connected)
+            InternalSessionInfo session = new InternalSessionInfo();
+            if (Interlocked.CompareExchange(ref SessionInfo, session, null!) == null)
             {
-                return;
-            }
-            string sessionKey = await AuthorizeAsync(options);
-            await VerifyAsync(options, sessionKey, qqNumber);
-            ApiVersion = await GetVersionAsync(options);
-            InternalSessionInfo session = new InternalSessionInfo
-            {
-                Options = options,
-                SessionKey = sessionKey,
-                QQNumber = qqNumber,
-                Canceller = new CancellationTokenSource()
-            };
-            try
-            {
-                IMiraiSessionConfig config = await this.GetConfigAsync(session);
-                if (!config.EnableWebSocket.GetValueOrDefault())
+                try
                 {
-                    await this.SetConfigAsync(session, new MiraiSessionConfig { CacheSize = config.CacheSize, EnableWebSocket = true });
+                    session.SessionKey = await AuthorizeAsync(options);
+                    session.Options = options;
+                    await VerifyAsync(options, session.SessionKey, qqNumber);
+                    session.QQNumber = qqNumber;
+                    session.ApiVersion = await GetVersionAsync(options);
+                    CancellationTokenSource canceller = new CancellationTokenSource();
+                    session.Canceller = canceller;
+                    session.Token = canceller.Token;
+                    session.Connected = true;
+                    IMiraiSessionConfig config = await this.GetConfigAsync(session);
+                    if (!config.EnableWebSocket.GetValueOrDefault())
+                    {
+                        await this.SetConfigAsync(session, new MiraiSessionConfig { CacheSize = config.CacheSize, EnableWebSocket = true });
+                    }
+                    CancellationToken token = session.Canceller.Token;
+                    ReceiveMessageLoop(session, token);
+                    if (listenCommand)
+                    {
+                        ReceiveCommandLoop(session, token);
+                    }
                 }
-                CancellationToken token = session.Canceller.Token;
-                ReceiveMessageLoop(session, token);
-                if (listenCommand)
+                catch
                 {
-                    ReceiveCommandLoop(session, token);
+                    SessionInfo = null!;
+                    _ = InternalReleaseAsync(session);
+                    throw;
                 }
-                SessionInfo = session;
-            }
-            catch // 如果这都报错那真是见了鬼了
-            {
-                _ = InternalReleaseAsync(session);
-                throw;
             }
         }
 
@@ -84,7 +83,7 @@ namespace Mirai_CSharp
             int code = root.GetProperty("code").GetInt32();
             return code switch
             {
-                0 => root.GetProperty("session").GetString(),
+                0 => root.GetProperty("session").GetString()!,
                 _ => ThrowCommonException<string>(code, in root)
             };
         }
@@ -110,7 +109,11 @@ namespace Mirai_CSharp
             int code = root.GetProperty("code").GetInt32();
             if (code == 0)
             {
-                return Version.Parse(root.GetProperty("data").GetProperty("version").GetString()[1..]); // v1.0.0, skip 'v'
+#if NETSTANDARD2_0
+                return Version.Parse(root.GetProperty("data").GetProperty("version").GetString()!.Substring(1)); // v1.0.0, skip 'v'
+#else
+                return Version.Parse(root.GetProperty("data").GetProperty("version").GetString()![1..]); // v1.0.0, skip 'v'
+#endif
             }
             return ThrowCommonException<Version>(code, in root);
         }
@@ -122,7 +125,7 @@ namespace Mirai_CSharp
         public Task ReleaseAsync(CancellationToken token = default)
         {
             CheckDisposed();
-            InternalSessionInfo session = Interlocked.Exchange(ref SessionInfo, null);
+            InternalSessionInfo? session = Interlocked.Exchange(ref SessionInfo, null!);
             if (session == null)
             {
                 throw new InvalidOperationException("请先连接到一个Session。");
@@ -132,13 +135,9 @@ namespace Mirai_CSharp
 
         private Task InternalReleaseAsync(InternalSessionInfo session, CancellationToken token = default)
         {
-            Plugins = null;
-            foreach (FieldInfo eventField in typeof(MiraiHttpSession).GetEvents().Select(p => typeof(MiraiHttpSession).GetField(p.Name, BindingFlags.NonPublic | BindingFlags.Instance)))
-            {
-                eventField.SetValue(this, null); // 用反射解决掉所有事件的Handler
-            }
-            session.Canceller.Cancel();
-            session.Canceller.Dispose();
+            session.Connected = false;
+            session.Canceller?.Cancel();
+            session.Canceller?.Dispose();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
                 sessionKey = session.SessionKey,

--- a/Mirai-CSharp/Session/MiraiHttpSession.Command.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Command.cs
@@ -22,7 +22,7 @@ namespace Mirai_CSharp
         /// <param name="alias">指令别名</param>
         /// <param name="description">指令描述</param>
         /// <param name="usage">指令用法, 会在指令执行错误时显示</param>
-        public static async Task RegisterCommandAsync(MiraiHttpSessionOptions options, string name, string[] alias = null, string description = null, string usage = null)
+        public static async Task RegisterCommandAsync(MiraiHttpSessionOptions options, string name, string[]? alias = null, string? description = null, string? usage = null)
         {
             if (string.IsNullOrEmpty(name))
             {
@@ -56,10 +56,10 @@ namespace Mirai_CSharp
         /// <param name="alias">指令别名</param>
         /// <param name="description">指令描述</param>
         /// <param name="usage">指令用法, 会在指令执行错误时显示</param>
-        public Task RegisterCommandAsync(string name, string[] alias = null, string description = null, string usage = null)
+        public Task RegisterCommandAsync(string name, string[]? alias = null, string? description = null, string? usage = null)
         {
-            CheckConnected();
-            return RegisterCommandAsync(SessionInfo.Options, name, alias, description, usage);
+            InternalSessionInfo session = SafeGetSession();
+            return RegisterCommandAsync(session.Options, name, alias, description, usage);
         }
         /// <summary>
         /// 异步执行指令
@@ -104,8 +104,8 @@ namespace Mirai_CSharp
         /// <param name="args">指令参数</param>
         public Task ExecuteCommandAsync(string name, params string[] args)
         {
-            CheckConnected();
-            return ExecuteCommandAsync(SessionInfo.Options, name, args);
+            InternalSessionInfo session = SafeGetSession();
+            return ExecuteCommandAsync(session.Options, name, args);
         }
         /// <summary>
         /// 异步获取给定QQ的Managers
@@ -134,8 +134,8 @@ namespace Mirai_CSharp
         /// <returns>能够管理此机器人的QQ号数组</returns>
         public Task<long[]> GetManagersAsync(long qqNumber)
         {
-            CheckConnected();
-            return GetManagersAsync(SessionInfo.Options, qqNumber, SessionInfo.Canceller.Token);
+            InternalSessionInfo session = SafeGetSession();
+            return GetManagersAsync(session.Options, qqNumber, session.Token);
         }
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Configuration.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Configuration.cs
@@ -31,8 +31,8 @@ namespace Mirai_CSharp
         /// </summary>
         public Task<IMiraiSessionConfig> GetConfigAsync()
         {
-            CheckConnected();
-            return GetConfigAsync(SessionInfo);
+            InternalSessionInfo session = SafeGetSession();
+            return GetConfigAsync(session);
         }
         /// <summary>
         /// 异步设置当前Session的Config
@@ -40,8 +40,8 @@ namespace Mirai_CSharp
         /// <param name="config">配置信息</param>
         public Task SetConfigAsync(IMiraiSessionConfig config)
         {
-            CheckConnected();
-            return SetConfigAsync(SessionInfo, config);
+            InternalSessionInfo session = SafeGetSession();
+            return SetConfigAsync(session, config);
         }
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Events.Bot.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Events.Bot.cs
@@ -7,50 +7,50 @@ namespace Mirai_CSharp
         /// <summary>
         /// Bot登录成功
         /// </summary>
-        public event CommonEventHandler<IBotOnlineEventArgs> BotOnlineEvt;
+        public event CommonEventHandler<IBotOnlineEventArgs>? BotOnlineEvt;
         /// <summary>
         /// Bot主动离线
         /// </summary>
-        public event CommonEventHandler<IBotPositiveOfflineEventArgs> BotPositiveOfflineEvt;
+        public event CommonEventHandler<IBotPositiveOfflineEventArgs>? BotPositiveOfflineEvt;
         /// <summary>
         /// Bot被挤下线
         /// </summary>
-        public event CommonEventHandler<IBotKickedOfflineEventArgs> BotKickedOfflineEvt;
+        public event CommonEventHandler<IBotKickedOfflineEventArgs>? BotKickedOfflineEvt;
         /// <summary>
         /// Bot意外断开连接(服务器主动断开连接、网络问题等等)
         /// </summary>
-        public event CommonEventHandler<IBotDroppedEventArgs> BotDroppedEvt;
+        public event CommonEventHandler<IBotDroppedEventArgs>? BotDroppedEvt;
         /// <summary>
         /// Bot主动重新登录
         /// </summary>
-        public event CommonEventHandler<IBotReloginEventArgs> BotReloginEvt;
+        public event CommonEventHandler<IBotReloginEventArgs>? BotReloginEvt;
         /// <summary>
         /// Bot在群里的权限被改变. 操作人一定是群主
         /// </summary>
-        public event CommonEventHandler<IBotGroupPermissionChangedEventArgs> BotGroupPermissionChangedEvt;
+        public event CommonEventHandler<IBotGroupPermissionChangedEventArgs>? BotGroupPermissionChangedEvt;
         /// <summary>
         /// Bot被禁言
         /// </summary>
-        public event CommonEventHandler<IBotMutedEventArgs> BotMutedEvt;
+        public event CommonEventHandler<IBotMutedEventArgs>? BotMutedEvt;
         /// <summary>
         /// Bot被取消禁言
         /// </summary>
-        public event CommonEventHandler<IBotUnmutedEventArgs> BotUnmutedEvt;
+        public event CommonEventHandler<IBotUnmutedEventArgs>? BotUnmutedEvt;
         /// <summary>
         /// Bot加入了一个新群
         /// </summary>
-        public event CommonEventHandler<IBotJoinedGroupEventArgs> BotJoinedGroupEvt;
+        public event CommonEventHandler<IBotJoinedGroupEventArgs>? BotJoinedGroupEvt;
         /// <summary>
         /// Bot主动退出一个群
         /// </summary>
-        public event CommonEventHandler<IBotPositiveLeaveGroupEventArgs> BotPositiveLeaveGroupEvt;
+        public event CommonEventHandler<IBotPositiveLeaveGroupEventArgs>? BotPositiveLeaveGroupEvt;
         /// <summary>
         /// Bot被踢出一个群
         /// </summary>
-        public event CommonEventHandler<IBotKickedOutEventArgs> BotKickedOutEvt;
+        public event CommonEventHandler<IBotKickedOutEventArgs>? BotKickedOutEvt;
         /// <summary>
         /// Bot被邀请入群
         /// </summary>
-        public event CommonEventHandler<IBotInvitedJoinGroupEventArgs> BotInvitedJoinGroupEvt;
+        public event CommonEventHandler<IBotInvitedJoinGroupEventArgs>? BotInvitedJoinGroupEvt;
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Events.Command.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Events.Command.cs
@@ -7,6 +7,6 @@ namespace Mirai_CSharp
         /// <summary>
         /// 指令执行后引发的事件
         /// </summary>
-        public event CommonEventHandler<ICommandExecutedEventArgs> CommandExecuted;
+        public event CommonEventHandler<ICommandExecutedEventArgs>? CommandExecuted;
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Events.Friend.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Events.Friend.cs
@@ -7,14 +7,14 @@ namespace Mirai_CSharp
         /// <summary>
         /// 收到好友消息
         /// </summary>
-        public event CommonEventHandler<IFriendMessageEventArgs> FriendMessageEvt;
+        public event CommonEventHandler<IFriendMessageEventArgs>? FriendMessageEvt;
         /// <summary>
         /// 好友消息被撤回
         /// </summary>
-        public event CommonEventHandler<IFriendMessageRevokedEventArgs> FriendMessageRevokedEvt;
+        public event CommonEventHandler<IFriendMessageRevokedEventArgs>? FriendMessageRevokedEvt;
         /// <summary>
         /// 收到添加好友申请
         /// </summary>
-        public event CommonEventHandler<INewFriendApplyEventArgs> NewFriendApplyEvt;
+        public event CommonEventHandler<INewFriendApplyEventArgs>? NewFriendApplyEvt;
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Events.Group.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Events.Group.cs
@@ -7,70 +7,70 @@ namespace Mirai_CSharp
         /// <summary>
         /// 收到群消息
         /// </summary>
-        public event CommonEventHandler<IGroupMessageEventArgs> GroupMessageEvt;
+        public event CommonEventHandler<IGroupMessageEventArgs>? GroupMessageEvt;
         /// <summary>
         /// 群消息被撤回
         /// </summary>
-        public event CommonEventHandler<IGroupMessageRevokedEventArgs> GroupMessageRevokedEvt;
+        public event CommonEventHandler<IGroupMessageRevokedEventArgs>? GroupMessageRevokedEvt;
         /// <summary>
         /// 某个群名被改变
         /// </summary>
-        public event CommonEventHandler<IGroupNameChangedEventArgs> GroupNameChangedEvt;
+        public event CommonEventHandler<IGroupNameChangedEventArgs>? GroupNameChangedEvt;
         /// <summary>
         /// 某群入群公告改变
         /// </summary>
-        public event CommonEventHandler<IGroupEntranceAnnouncementChangedEventArgs> GroupEntranceAnnouncementChangedEvt;
+        public event CommonEventHandler<IGroupEntranceAnnouncementChangedEventArgs>? GroupEntranceAnnouncementChangedEvt;
         /// <summary>
         /// 全员禁言设置被改变
         /// </summary>
-        public event CommonEventHandler<IGroupMuteAllChangedEventArgs> GroupMuteAllChangedEvt;
+        public event CommonEventHandler<IGroupMuteAllChangedEventArgs>? GroupMuteAllChangedEvt;
         /// <summary>
         /// 匿名聊天设置被改变
         /// </summary>
-        public event CommonEventHandler<IGroupAnonymousChatChangedEventArgs> GroupAnonymousChatChangedEvt;
+        public event CommonEventHandler<IGroupAnonymousChatChangedEventArgs>? GroupAnonymousChatChangedEvt;
         /// <summary>
         /// 坦白说设置被改变
         /// </summary>
-        public event CommonEventHandler<IGroupConfessTalkChangedEventArgs> GroupConfessTalkChangedEvt;
+        public event CommonEventHandler<IGroupConfessTalkChangedEventArgs>? GroupConfessTalkChangedEvt;
         /// <summary>
         /// 群员邀请好友加群设置被改变
         /// </summary>
-        public event CommonEventHandler<IGroupMemberInviteChangedEventArgs> GroupMemberInviteChangedEvt;
+        public event CommonEventHandler<IGroupMemberInviteChangedEventArgs>? GroupMemberInviteChangedEvt;
         /// <summary>
         /// 新人入群
         /// </summary>
-        public event CommonEventHandler<IGroupMemberJoinedEventArgs> GroupMemberJoinedEvt;
+        public event CommonEventHandler<IGroupMemberJoinedEventArgs>? GroupMemberJoinedEvt;
         /// <summary>
         /// 成员主动离群（该成员不是Bot, 见 <see cref="BotPositiveLeaveGroupEvt"/>）
         /// </summary>
-        public event CommonEventHandler<IGroupMemberPositiveLeaveEventArgs> GroupMemberPositiveLeaveEvt;
+        public event CommonEventHandler<IGroupMemberPositiveLeaveEventArgs>? GroupMemberPositiveLeaveEvt;
         /// <summary>
         /// 成员被踢出群（该成员不是Bot, 见 <see cref="BotKickedOutEvt"/>）
         /// </summary>
-        public event CommonEventHandler<IGroupMemberKickedEventArgs> GroupMemberKickedEvt;
+        public event CommonEventHandler<IGroupMemberKickedEventArgs>? GroupMemberKickedEvt;
         /// <summary>
         /// 群名片改动
         /// </summary>
-        public event CommonEventHandler<IGroupMemberCardChangedEventArgs> GroupMemberCardChangedEvt;
+        public event CommonEventHandler<IGroupMemberCardChangedEventArgs>? GroupMemberCardChangedEvt;
         /// <summary>
         /// 群头衔改动（只有群主有操作限权）
         /// </summary>
-        public event CommonEventHandler<IGroupMemberSpecialTitleChangedEventArgs> GroupMemberSpecialTitleChangedEvt;
+        public event CommonEventHandler<IGroupMemberSpecialTitleChangedEventArgs>? GroupMemberSpecialTitleChangedEvt;
         /// <summary>
         /// 成员权限改变（该成员不是Bot, 见 <see cref="BotGroupPermissionChangedEvt"/>）
         /// </summary>
-        public event CommonEventHandler<IGroupMemberPermissionChangedEventArgs> GroupMemberPermissionChangedEvt;
+        public event CommonEventHandler<IGroupMemberPermissionChangedEventArgs>? GroupMemberPermissionChangedEvt;
         /// <summary>
         /// 群成员被禁言（该成员不可能是Bot, 见 <see cref="BotMutedEventArgs"/>）
         /// </summary>
-        public event CommonEventHandler<IGroupMemberMutedEventArgs> GroupMemberMutedEvt;
+        public event CommonEventHandler<IGroupMemberMutedEventArgs>? GroupMemberMutedEvt;
         /// <summary>
         /// 群成员被取消禁言（该成员不可能是Bot, 见 <see cref="BotUnmutedEventArgs"/>）
         /// </summary>
-        public event CommonEventHandler<IGroupMemberUnmutedEventArgs> GroupMemberUnmutedEvt;
+        public event CommonEventHandler<IGroupMemberUnmutedEventArgs>? GroupMemberUnmutedEvt;
         /// <summary>
         /// 收到用户入群申请（Bot需要有 <see cref="GroupPermission.Administrator"/> 或 <see cref="GroupPermission.Owner"/> 权限）
         /// </summary>
-        public event CommonEventHandler<IGroupApplyEventArgs> GroupApplyEvt;
+        public event CommonEventHandler<IGroupApplyEventArgs>? GroupApplyEvt;
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Events.Temp.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Events.Temp.cs
@@ -7,6 +7,6 @@ namespace Mirai_CSharp
         /// <summary>
         /// 收到临时消息
         /// </summary>
-        public event CommonEventHandler<ITempMessageEventArgs> TempMessageEvt;
+        public event CommonEventHandler<ITempMessageEventArgs>? TempMessageEvt;
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Events.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Events.cs
@@ -16,10 +16,10 @@ namespace Mirai_CSharp
         /// <summary>
         /// 与mirai-api-http的ws连接被异常断开
         /// </summary>
-        public event CommonEventHandler<Exception> DisconnectedEvt;
+        public event CommonEventHandler<Exception>? DisconnectedEvt;
         /// <summary>
         /// 收到未知消息。如有需要, 请自行解析
         /// </summary>
-        public event CommonEventHandler<IUnknownMessageEventArgs> UnknownMessageEvt; 
+        public event CommonEventHandler<IUnknownMessageEventArgs>? UnknownMessageEvt; 
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Invoking.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Invoking.cs
@@ -9,10 +9,10 @@ namespace Mirai_CSharp
 {
     public partial class MiraiHttpSession
     {
-        private static Task<bool> InvokeAsync<TEventArgs>(IPlugin plugin, MiraiHttpSession session, TEventArgs e)
-        {
-            return plugin is IPlugin<TEventArgs> ? ((IPlugin<TEventArgs>)plugin).HandleEvent(session, e) : Task.FromResult(false);
-        }
+        //private static Task<bool> InvokeAsync<TEventArgs>(IPlugin plugin, MiraiHttpSession session, TEventArgs e)
+        //{
+        //    return plugin is IPlugin<TEventArgs> ? ((IPlugin<TEventArgs>)plugin).HandleEvent(session, e) : Task.FromResult(false);
+        //}
 
         //public static Task<bool> InvokeAsync<TPlugin, TEventArgs>(this IPlugin plugin, MiraiHttpSession session, TEventArgs e) where TPlugin : IPlugin<TEventArgs>
         //{
@@ -20,13 +20,13 @@ namespace Mirai_CSharp
         //    return plugin is TPlugin ? ((TPlugin)plugin).HandleEvent(session, e) : Task.FromResult(false);
         //}
 
-        private static async Task InvokeAsync<TPlugin, TEventArgs>(IEnumerable<IPlugin> plugins, CommonEventHandler<TEventArgs> handlers, MiraiHttpSession session, TEventArgs e) where TPlugin : IPlugin<TEventArgs>
+        private static async Task InvokeAsync<TEventArgs>(IEnumerable<IPlugin> plugins, CommonEventHandler<TEventArgs>? handlers, MiraiHttpSession session, TEventArgs e)
         {
             try
             {
                 foreach (IPlugin plugin in plugins)
                 {
-                    if (await InvokeAsync(plugin, session, e))
+                    if (plugin is IPlugin<TEventArgs> tPlugin && await tPlugin.HandleEvent(session, e))
                     {
                         return;
                     }

--- a/Mirai-CSharp/Session/MiraiHttpSession.Management.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Management.cs
@@ -15,8 +15,8 @@ namespace Mirai_CSharp
         /// <exception cref="InvalidOperationException"/>
         public Task<IFriendInfo[]> GetFriendListAsync()
         {
-            CheckConnected();
-            return InternalHttpGetAsync<IFriendInfo[], FriendInfo[]>($"{SessionInfo.Options.BaseUrl}/friendList?sessionKey={SessionInfo.SessionKey}", SessionInfo.Canceller.Token);
+            InternalSessionInfo session = SafeGetSession();
+            return InternalHttpGetAsync<IFriendInfo[], FriendInfo[]>($"{session.Options.BaseUrl}/friendList?sessionKey={session.SessionKey}", session.Token);
         }
         /// <summary>
         /// 异步获取群列表
@@ -24,8 +24,8 @@ namespace Mirai_CSharp
         /// <exception cref="InvalidOperationException"/>
         public Task<IGroupInfo[]> GetGroupListAsync()
         {
-            CheckConnected();
-            return InternalHttpGetAsync<IGroupInfo[], GroupInfo[]>($"{SessionInfo.Options.BaseUrl}/groupList?sessionKey={SessionInfo.SessionKey}", SessionInfo.Canceller.Token);
+            InternalSessionInfo session = SafeGetSession();
+            return InternalHttpGetAsync<IGroupInfo[], GroupInfo[]>($"{session.Options.BaseUrl}/groupList?sessionKey={session.SessionKey}", session.Token);
         }
         /// <summary>
         /// 异步获取群成员列表
@@ -35,19 +35,19 @@ namespace Mirai_CSharp
         /// <param name="groupNumber">将要进行查询的群号</param>
         public Task<IGroupMemberInfo[]> GetGroupMemberListAsync(long groupNumber)
         {
-            CheckConnected();
-            return InternalHttpGetAsync<IGroupMemberInfo[], GroupMemberInfo[]>($"{SessionInfo.Options.BaseUrl}/memberList?sessionKey={SessionInfo.SessionKey}&target={groupNumber}", SessionInfo.Canceller.Token);
+            InternalSessionInfo session = SafeGetSession();
+            return InternalHttpGetAsync<IGroupMemberInfo[], GroupMemberInfo[]>($"{session.Options.BaseUrl}/memberList?sessionKey={session.SessionKey}&target={groupNumber}", session.Token);
         }
 
         private Task InternalToggleMuteAllAsync(bool action, long groupNumber)
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/{(action ? "muteAll" : "unmuteAll")}", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/{(action ? "muteAll" : "unmuteAll")}", payload, session.Token);
         }
         /// <summary>
         /// 异步开启全体禁言
@@ -82,19 +82,19 @@ namespace Mirai_CSharp
         /// <param name="duration">禁言时长。必须介于[1秒, 30天]</param>
         public Task MuteAsync(long memberId, long groupNumber, TimeSpan duration)
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             if (duration <= TimeSpan.Zero || duration >= TimeSpan.FromDays(30))
             {
                 throw new ArgumentOutOfRangeException(nameof(duration));
             }
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber,
                 memberId,
                 time = (int)duration.TotalSeconds
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/mute", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/mute", payload, session.Token);
         }
         /// <summary>
         /// 异步解禁给定用户
@@ -106,14 +106,14 @@ namespace Mirai_CSharp
         /// <param name="groupNumber">该用户所在群号</param>
         public Task UnmuteAsync(long memberId, long groupNumber)
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber,
                 memberId,
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/unmute", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/unmute", payload, session.Token);
         }
         /// <summary>
         /// 异步将给定用户踢出给定的群
@@ -126,15 +126,15 @@ namespace Mirai_CSharp
         /// <param name="msg">附加消息</param>
         public Task KickMemberAsync(long memberId, long groupNumber, string msg = "您已被移出群聊")
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber,
                 memberId,
                 msg
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/kick", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/kick", payload, session.Token);
         }
         /// <summary>
         /// 异步使当前机器人退出给定的群
@@ -144,13 +144,13 @@ namespace Mirai_CSharp
         /// <param name="groupNumber">将要退出的群号</param>
         public Task LeaveGroupAsync(long groupNumber)
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber,
             });
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/quit", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/quit", payload, session.Token);
         }
         /// <summary>
         /// 异步修改群信息
@@ -162,14 +162,14 @@ namespace Mirai_CSharp
         /// <param name="config">群信息。其中不进行修改的值请置为 <see langword="null"/></param>
         public Task ChangeGroupConfigAsync(long groupNumber, IGroupConfig config)
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber,
                 config
             }, JsonSerializeOptionsFactory.IgnoreNulls);
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/groupConfig", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/groupConfig", payload, session.Token);
         }
         /// <summary>
         /// 异步获取群信息
@@ -179,8 +179,8 @@ namespace Mirai_CSharp
         /// <param name="groupNumber">要获取信息的群号</param>
         public Task<IGroupConfig> GetGroupConfigAsync(long groupNumber)
         {
-            CheckConnected();
-            return InternalHttpGetAsync<IGroupConfig, GroupConfig>($"{SessionInfo.Options.BaseUrl}/groupConfig?sessionKey={SessionInfo.SessionKey}&target={groupNumber}", SessionInfo.Canceller.Token);
+            InternalSessionInfo session = SafeGetSession();
+            return InternalHttpGetAsync<IGroupConfig, GroupConfig>($"{session.Options.BaseUrl}/groupConfig?sessionKey={session.SessionKey}&target={groupNumber}", session.Token);
         }
         /// <summary>
         /// 异步修改给定群员的信息
@@ -193,15 +193,15 @@ namespace Mirai_CSharp
         /// <param name="info">用户信息。其中不进行修改的值请置为 <see langword="null"/></param>
         public Task ChangeGroupMemberInfoAsync(long memberId, long groupNumber, IGroupMemberCardInfo info)
         {
-            CheckConnected();
+            InternalSessionInfo session = SafeGetSession();
             byte[] payload = JsonSerializer.SerializeToUtf8Bytes(new
             {
-                sessionKey = SessionInfo.SessionKey,
+                sessionKey = session.SessionKey,
                 target = groupNumber,
                 memberId,
                 info
             }, JsonSerializeOptionsFactory.IgnoreNulls);
-            return InternalHttpPostAsync($"{SessionInfo.Options.BaseUrl}/memberInfo", payload, SessionInfo.Canceller.Token);
+            return InternalHttpPostAsync($"{session.Options.BaseUrl}/memberInfo", payload, session.Token);
         }
         /// <summary>
         /// 异步获取给定群员的信息
@@ -212,8 +212,8 @@ namespace Mirai_CSharp
         /// <param name="groupNumber">该用户所在群号</param>
         public Task<IGroupMemberCardInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber)
         {
-            CheckConnected();
-            return InternalHttpGetAsync<IGroupMemberCardInfo, GroupMemberCardInfo>($"{SessionInfo.Options.BaseUrl}/memberInfo?sessionKey={SessionInfo.SessionKey}&target={groupNumber}&memberId={memberId}", SessionInfo.Canceller.Token);
+            InternalSessionInfo session = SafeGetSession();
+            return InternalHttpGetAsync<IGroupMemberCardInfo, GroupMemberCardInfo>($"{session.Options.BaseUrl}/memberInfo?sessionKey={session.SessionKey}&target={groupNumber}&memberId={memberId}", session.Token);
         }
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.ReceiveMessage.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.ReceiveMessage.cs
@@ -1,5 +1,4 @@
 ﻿using Mirai_CSharp.Models;
-using Mirai_CSharp.Plugin.Interfaces;
 using Mirai_CSharp.Utility;
 using System;
 using System.IO;
@@ -21,179 +20,177 @@ namespace Mirai_CSharp
                 while (true)
                 {
                     using MemoryStream ms = await ws.ReceiveFullyAsync(token);
-                    ms.Seek(0, SeekOrigin.Begin);
-                    using JsonDocument j = await JsonDocument.ParseAsync(ms, default, token);
-                    JsonElement root = j.RootElement;
+                    JsonElement root = JsonSerializer.Deserialize<JsonElement>(new ReadOnlySpan<byte>(ms.GetBuffer(), 0, (int)ms.Length));
                     switch (root.GetProperty("type").GetString())
                     {
                         case "BotOnlineEvent":
                             {
-                                _ = InvokeAsync<IBotOnline, IBotOnlineEventArgs>(Plugins, BotOnlineEvt, this, root.Deserialize<BotEventArgs>());
+                                _ = InvokeAsync(Plugins, BotOnlineEvt, this, root.Deserialize<BotEventArgs>());
                                 break;
                             }
                         case "BotOfflineEventActive":
                             {
-                                _ = InvokeAsync<IBotPositiveOffline, IBotPositiveOfflineEventArgs>(Plugins, BotPositiveOfflineEvt, this, root.Deserialize<BotEventArgs>());
+                                _ = InvokeAsync(Plugins, BotPositiveOfflineEvt, this, root.Deserialize<BotEventArgs>());
                                 break;
                             }
                         case "BotOfflineEventForce":
                             {
-                                _ = InvokeAsync<IBotKickedOffline, IBotKickedOfflineEventArgs>(Plugins, BotKickedOfflineEvt, this, root.Deserialize<BotEventArgs>());
+                                _ = InvokeAsync(Plugins, BotKickedOfflineEvt, this, root.Deserialize<BotEventArgs>());
                                 break;
                             }
                         case "BotOfflineEventDropped":
                             {
-                                _ = InvokeAsync<IBotDropped, IBotDroppedEventArgs>(Plugins, BotDroppedEvt, this, root.Deserialize<BotEventArgs>());
+                                _ = InvokeAsync(Plugins, BotDroppedEvt, this, root.Deserialize<BotEventArgs>());
                                 break;
                             }
                         case "BotReloginEvent":
                             {
-                                _ = InvokeAsync<IBotRelogin, IBotReloginEventArgs>(Plugins, BotReloginEvt, this, root.Deserialize<BotEventArgs>());
+                                _ = InvokeAsync(Plugins, BotReloginEvt, this, root.Deserialize<BotEventArgs>());
                                 break;
                             }
                         case "BotInvitedJoinGroupRequestEvent":
                             {
-                                _ = InvokeAsync<IBotInvitedJoinGroup, IBotInvitedJoinGroupEventArgs>(Plugins, BotInvitedJoinGroupEvt, this, root.Deserialize<CommonGroupApplyEventArgs>());
+                                _ = InvokeAsync(Plugins, BotInvitedJoinGroupEvt, this, root.Deserialize<CommonGroupApplyEventArgs>());
                                 break;
                             }
                         case "FriendMessage":
                             {
-                                _ = InvokeAsync<IFriendMessage, IFriendMessageEventArgs>(Plugins, FriendMessageEvt, this, root.Deserialize<FriendMessageEventArgs>());
+                                _ = InvokeAsync(Plugins, FriendMessageEvt, this, root.Deserialize<FriendMessageEventArgs>());
                                 break;
                             }
                         case "GroupMessage":
                             {
-                                _ = InvokeAsync<IGroupMessage, IGroupMessageEventArgs>(Plugins, GroupMessageEvt, this, root.Deserialize<GroupMessageEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMessageEvt, this, root.Deserialize<GroupMessageEventArgs>());
                                 break;
                             }
                         case "TempMessage":
                             {
-                                _ = InvokeAsync<ITempMessage, ITempMessageEventArgs>(Plugins, TempMessageEvt, this, root.Deserialize<TempMessageEventArgs>());
+                                _ = InvokeAsync(Plugins, TempMessageEvt, this, root.Deserialize<TempMessageEventArgs>());
                                 break;
                             }
                         case "GroupRecallEvent":
                             {
-                                _ = InvokeAsync<IGroupMessageRevoked, IGroupMessageRevokedEventArgs>(Plugins, GroupMessageRevokedEvt, this, root.Deserialize<GroupMessageRevokedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMessageRevokedEvt, this, root.Deserialize<GroupMessageRevokedEventArgs>());
                                 break;
                             }
                         case "FriendRecallEvent":
                             {
-                                _ = InvokeAsync<IFriendMessageRevoked, IFriendMessageRevokedEventArgs>(Plugins, FriendMessageRevokedEvt, this, root.Deserialize<FriendMessageRevokedEventArgs>());
+                                _ = InvokeAsync(Plugins, FriendMessageRevokedEvt, this, root.Deserialize<FriendMessageRevokedEventArgs>());
                                 break;
                             }
                         case "BotGroupPermissionChangeEvent":
                             {
-                                _ = InvokeAsync<IBotGroupPermissionChanged, IBotGroupPermissionChangedEventArgs>(Plugins, BotGroupPermissionChangedEvt, this, root.Deserialize<BotGroupPermissionChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, BotGroupPermissionChangedEvt, this, root.Deserialize<BotGroupPermissionChangedEventArgs>());
                                 break;
                             }
                         case "BotMuteEvent":
                             {
-                                _ = InvokeAsync<IBotMuted, IBotMutedEventArgs>(Plugins, BotMutedEvt, this, root.Deserialize<BotMutedEventArgs>());
+                                _ = InvokeAsync(Plugins, BotMutedEvt, this, root.Deserialize<BotMutedEventArgs>());
                                 break;
                             }
                         case "BotUnmuteEvent":
                             {
-                                _ = InvokeAsync<IBotUnmuted, IBotUnmutedEventArgs>(Plugins, BotUnmutedEvt, this, root.Deserialize<BotUnmutedEventArgs>());
+                                _ = InvokeAsync(Plugins, BotUnmutedEvt, this, root.Deserialize<BotUnmutedEventArgs>());
                                 break;
                             }
                         case "BotJoinGroupEvent":
                             {
-                                _ = InvokeAsync<IBotJoinedGroup, IBotJoinedGroupEventArgs>(Plugins, BotJoinedGroupEvt, this, root.Deserialize<GroupEventArgs>());
+                                _ = InvokeAsync(Plugins, BotJoinedGroupEvt, this, root.Deserialize<GroupEventArgs>());
                                 break;
                             }
                         case "BotLeaveEventActive":
                             {
-                                _ = InvokeAsync<IBotPositiveLeaveGroup, IBotPositiveLeaveGroupEventArgs>(Plugins, BotPositiveLeaveGroupEvt, this, root.Deserialize<GroupEventArgs>());
+                                _ = InvokeAsync(Plugins, BotPositiveLeaveGroupEvt, this, root.Deserialize<GroupEventArgs>());
                                 break;
                             }
                         case "BotLeaveEventKick":
                             {
-                                _ = InvokeAsync<IBotKickedOut, IBotKickedOutEventArgs>(Plugins, BotKickedOutEvt, this, root.Deserialize<GroupEventArgs>());
+                                _ = InvokeAsync(Plugins, BotKickedOutEvt, this, root.Deserialize<GroupEventArgs>());
                                 break;
                             }
                         case "GroupNameChangeEvent":
                             {
-                                _ = InvokeAsync<IGroupNameChanged, IGroupNameChangedEventArgs>(Plugins, GroupNameChangedEvt, this, root.Deserialize<GroupStringPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupNameChangedEvt, this, root.Deserialize<GroupStringPropertyChangedEventArgs>());
                                 break;
                             }
                         case "GroupEntranceAnnouncementChangeEvent":
                             {
-                                _ = InvokeAsync<IGroupEntranceAnnouncementChanged, IGroupEntranceAnnouncementChangedEventArgs>(Plugins, GroupEntranceAnnouncementChangedEvt, this, root.Deserialize<GroupStringPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupEntranceAnnouncementChangedEvt, this, root.Deserialize<GroupStringPropertyChangedEventArgs>());
                                 break;
                             }
                         case "GroupMuteAllEvent":
                             {
-                                _ = InvokeAsync<IGroupMuteAllChanged, IGroupMuteAllChangedEventArgs>(Plugins, GroupMuteAllChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMuteAllChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
                                 break;
                             }
                         case "GroupAllowAnonymousChatEvent":
                             {
-                                _ = InvokeAsync<IGroupAnonymousChatChanged, IGroupAnonymousChatChangedEventArgs>(Plugins, GroupAnonymousChatChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupAnonymousChatChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
                                 break;
                             }
                         case "GroupAllowConfessTalkEvent":
                             {
-                                _ = InvokeAsync<IGroupConfessTalkChanged, IGroupConfessTalkChangedEventArgs>(Plugins, GroupConfessTalkChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupConfessTalkChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
                                 break;
                             }
                         case "GroupAllowMemberInviteEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberInviteChanged, IGroupMemberInviteChangedEventArgs>(Plugins, GroupMemberInviteChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberInviteChangedEvt, this, root.Deserialize<GroupBoolPropertyChangedEventArgs>());
                                 break;
                             }
                         case "MemberJoinEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberJoined, IGroupMemberJoinedEventArgs>(Plugins, GroupMemberJoinedEvt, this, root.Deserialize<MemberEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberJoinedEvt, this, root.Deserialize<MemberEventArgs>());
                                 break;
                             }
                         case "MemberLeaveEventKick":
                             {
-                                _ = InvokeAsync<IGroupMemberKicked, IGroupMemberKickedEventArgs>(Plugins, GroupMemberKickedEvt, this, root.Deserialize<MemberOperatingEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberKickedEvt, this, root.Deserialize<MemberOperatingEventArgs>());
                                 break;
                             }
                         case "MemberLeaveEventQuit":
                             {
-                                _ = InvokeAsync<IGroupMemberPositiveLeave, IGroupMemberPositiveLeaveEventArgs>(Plugins, GroupMemberPositiveLeaveEvt, this, root.Deserialize<MemberEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberPositiveLeaveEvt, this, root.Deserialize<MemberEventArgs>());
                                 break;
                             }
                         case "MemberCardChangeEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberCardChanged, IGroupMemberCardChangedEventArgs>(Plugins, GroupMemberCardChangedEvt, this, root.Deserialize<GroupMemberStringPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberCardChangedEvt, this, root.Deserialize<GroupMemberStringPropertyChangedEventArgs>());
                                 break;
                             }
                         case "MemberSpecialTitleChangeEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberSpecialTitleChanged, IGroupMemberSpecialTitleChangedEventArgs>(Plugins, GroupMemberSpecialTitleChangedEvt, this, root.Deserialize<GroupMemberStringPropertyChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberSpecialTitleChangedEvt, this, root.Deserialize<GroupMemberStringPropertyChangedEventArgs>());
                                 break;
                             }
                         case "MemberPermissionChangeEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberPermissionChanged, IGroupMemberPermissionChangedEventArgs>(Plugins, GroupMemberPermissionChangedEvt, this, root.Deserialize<GroupMemberPermissionChangedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberPermissionChangedEvt, this, root.Deserialize<GroupMemberPermissionChangedEventArgs>());
                                 break;
                             }
                         case "MemberMuteEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberMuted, IGroupMemberMutedEventArgs>(Plugins, GroupMemberMutedEvt, this, root.Deserialize<GroupMemberMutedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberMutedEvt, this, root.Deserialize<GroupMemberMutedEventArgs>());
                                 break;
                             }
                         case "MemberUnmuteEvent":
                             {
-                                _ = InvokeAsync<IGroupMemberUnmuted, IGroupMemberUnmutedEventArgs>(Plugins, GroupMemberUnmutedEvt, this, root.Deserialize<GroupMemberUnmutedEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupMemberUnmutedEvt, this, root.Deserialize<GroupMemberUnmutedEventArgs>());
                                 break;
                             }
                         case "NewFriendRequestEvent":
                             {
-                                _ = InvokeAsync<INewFriendApply, INewFriendApplyEventArgs>(Plugins, NewFriendApplyEvt, this, root.Deserialize<NewFriendApplyEventArgs>());
+                                _ = InvokeAsync(Plugins, NewFriendApplyEvt, this, root.Deserialize<NewFriendApplyEventArgs>());
                                 break;
                             }
                         case "MemberJoinRequestEvent":
                             {
-                                _ = InvokeAsync<IGroupApply, IGroupApplyEventArgs>(Plugins, GroupApplyEvt, this, root.Deserialize<CommonGroupApplyEventArgs>());
+                                _ = InvokeAsync(Plugins, GroupApplyEvt, this, root.Deserialize<CommonGroupApplyEventArgs>());
                                 break;
                             }
                         default:
                             {
-                                _ = InvokeAsync<IUnknownMessage, IUnknownMessageEventArgs>(Plugins, UnknownMessageEvt, this, new UnknownMessageEventArgs(root.Clone()));
+                                _ = InvokeAsync(Plugins, UnknownMessageEvt, this, new UnknownMessageEventArgs(root.Clone()));
                                 break;
                             }
                     }
@@ -216,7 +213,6 @@ namespace Mirai_CSharp
         private async void ReceiveCommandLoop(InternalSessionInfo session, CancellationToken token)
         {
             using ClientWebSocket ws = new ClientWebSocket();
-            ws.Options.KeepAliveInterval = TimeSpan.FromSeconds(-1);
             try
             {
                 await ws.ConnectAsync(new Uri($"ws://{session.Options.Host}:{session.Options.Port}/command?authKey={session.Options.AuthKey}"), token);
@@ -226,7 +222,7 @@ namespace Mirai_CSharp
                     ms.Seek(0, SeekOrigin.Begin);
                     using JsonDocument j = await JsonDocument.ParseAsync(ms, default, token);
                     JsonElement root = j.RootElement;
-                    _ = InvokeAsync<ICommandExecuted, ICommandExecutedEventArgs>(Plugins, CommandExecuted, this, root.Deserialize<CommandExecutedEventArgs>());
+                    _ = InvokeAsync(Plugins, CommandExecuted, this, root.Deserialize<CommandExecutedEventArgs>());
                 }
             }
             catch (OperationCanceledException)

--- a/Mirai-CSharp/Session/MiraiHttpSession.Validation.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Validation.cs
@@ -23,7 +23,9 @@ namespace Mirai_CSharp
         /// <exception cref="MessageTooLongException"/>
         /// <exception cref="ArgumentException"/>
         /// <exception cref="UnknownResponseException"/>
+#if !NETSTANDARD2_0
         [DoesNotReturn]
+#endif
         private static T ThrowCommonException<T>(int code, in JsonElement root)
         {
             switch (code)
@@ -83,13 +85,11 @@ namespace Mirai_CSharp
             }
         }
 
-        private void CheckConnected()
+        private InternalSessionInfo SafeGetSession()
         {
             CheckDisposed();
-            if (!Connected)
-            {
-                throw new InvalidOperationException("请先连接到一个Session。");
-            }
+            InternalSessionInfo? session = SessionInfo;
+            return session ?? throw new InvalidOperationException("请先连接到一个Session。");
         }
     }
 }

--- a/Mirai-CSharp/Session/MiraiHttpSession.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.cs
@@ -2,6 +2,8 @@
 using Mirai_CSharp.Plugin;
 using System;
 using System.Collections.Immutable;
+using System.Linq;
+using System.Reflection;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -12,15 +14,13 @@ namespace Mirai_CSharp
         /// <summary>
         /// Session连接状态
         /// </summary>
-        public bool Connected => SessionInfo != null;
+        public bool Connected => SessionInfo?.Connected ?? false;
         /// <summary>
         /// Session绑定的QQ号。未连接为 <see langword="null"/>。
         /// </summary>
         public long? QQNumber => SessionInfo?.QQNumber;
 
-        private Version ApiVersion;
-
-        private InternalSessionInfo SessionInfo;
+        private InternalSessionInfo? SessionInfo;
 
         private ImmutableList<IPlugin> Plugins = Array.Empty<IPlugin>().ToImmutableList();
 
@@ -28,13 +28,19 @@ namespace Mirai_CSharp
 
         private class InternalSessionInfo
         {
-            public MiraiHttpSessionOptions Options;
+            public MiraiHttpSessionOptions Options = null!;
 
-            public string SessionKey;
+            public Version ApiVersion = null!;
+
+            public string SessionKey = null!;
 
             public long QQNumber;
 
-            public volatile CancellationTokenSource Canceller;
+            public CancellationToken Token;
+
+            public CancellationTokenSource Canceller = null!;
+
+            public bool Connected;
         }
 
         /// <summary>
@@ -72,9 +78,14 @@ namespace Mirai_CSharp
                 }
                 _disposed = true;
             }
-            InternalSessionInfo session = Interlocked.Exchange(ref SessionInfo, null);
+            InternalSessionInfo? session = Interlocked.Exchange(ref SessionInfo, null);
             if (session != null)
             {
+                Plugins = null!;
+                foreach (FieldInfo eventField in typeof(MiraiHttpSession).GetEvents().Select(p => typeof(MiraiHttpSession).GetField(p.Name, BindingFlags.NonPublic | BindingFlags.Instance)!))
+                {
+                    eventField.SetValue(this, null); // 用反射解决掉所有事件的Handler
+                }
                 return new ValueTask(this.InternalReleaseAsync(session));
             }
             return default;

--- a/Mirai-CSharp/Utility/ImageHttpListener.cs
+++ b/Mirai-CSharp/Utility/ImageHttpListener.cs
@@ -57,7 +57,7 @@ namespace Mirai_CSharp.Utility
                     if (ctx.Request.HttpMethod == "GET" &&
                         ctx.Request.Url.AbsolutePath == "/fetch" &&
                         Guid.TryParse(ctx.Request.QueryString["guid"], out Guid guid) &&
-                        Cache.TryRemove(guid, out Stream imgStream))
+                        Cache.TryRemove(guid, out Stream? imgStream))
                     {
                         using (imgStream)
                         {

--- a/Mirai-CSharp/Utility/JsonConverters/ChangeTypeJsonConverter.cs
+++ b/Mirai-CSharp/Utility/JsonConverters/ChangeTypeJsonConverter.cs
@@ -8,12 +8,12 @@ namespace Mirai_CSharp.Utility.JsonConverters
     {
         public override TDst Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return JsonSerializer.Deserialize<TSrc>(ref reader, options);
+            return JsonSerializer.Deserialize<TSrc>(ref reader, options)!;
         }
 
         public override void Write(Utf8JsonWriter writer, TDst value, JsonSerializerOptions options)
         {
-            JsonSerializer.Serialize<object>(writer, value, options); // TDst : interface 时, 不使用object的泛型参数将导致基接口成员不会被序列化
+            JsonSerializer.Serialize<object>(writer, value!, options); // TDst : interface 时, 不使用object的泛型参数将导致基接口成员不会被序列化
         }
     }
 }

--- a/Mirai-CSharp/Utility/JsonConverters/IMessageBaseArrayConverter.cs
+++ b/Mirai-CSharp/Utility/JsonConverters/IMessageBaseArrayConverter.cs
@@ -10,7 +10,7 @@ namespace Mirai_CSharp.Utility.JsonConverters
     {
         public override IMessageBase[] Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            List<MessageBase> result = new List<MessageBase>();
+            List<IMessageBase> result = new List<IMessageBase>();
             while (reader.Read() && reader.TokenType != JsonTokenType.EndArray)
             {
                 JsonElement data = JsonSerializer.Deserialize<JsonElement>(ref reader, options);
@@ -30,7 +30,7 @@ namespace Mirai_CSharp.Utility.JsonConverters
                     PokeMessage.MsgType => Utils.Deserialize<PokeMessage>(in data, options),
                     VoiceMessage.MsgType => Utils.Deserialize<VoiceMessage>(in data, options),
                     UnknownMessage.MsgType => Utils.Deserialize<UnknownMessage>(in data, options),
-                    _ => default
+                    _ => throw new NotImplementedException("未知的消息类型:" + data.GetProperty("type").GetString())
                 });
             }
             return result.ToArray();

--- a/Mirai-CSharp/Utility/JsonConverters/UnixTimeStampJsonConverter.cs
+++ b/Mirai-CSharp/Utility/JsonConverters/UnixTimeStampJsonConverter.cs
@@ -11,7 +11,7 @@ namespace Mirai_CSharp.Utility.JsonConverters
             return reader.TokenType switch
             {
                 JsonTokenType.Number => Utils.UnixTimeStamp2DateTime(reader.GetInt32()),
-                JsonTokenType.String => DateTime.Parse(reader.GetString()),
+                JsonTokenType.String => DateTime.Parse(reader.GetString()!),
                 _ => throw new ArgumentException($"Expected unix timestamp or datetime string, got {reader.TokenType}")
             };
         }

--- a/Mirai-CSharp/Utility/Utils.cs
+++ b/Mirai-CSharp/Utility/Utils.cs
@@ -1,9 +1,6 @@
-﻿using Mirai_CSharp.Plugin;
-using System;
-using System.Collections.Generic;
+﻿using System;
 using System.Reflection;
 using System.Text.Json;
-using System.Threading.Tasks;
 
 namespace Mirai_CSharp.Utility
 {
@@ -21,17 +18,17 @@ namespace Mirai_CSharp.Utility
         public static long DateTime2UnixTimeStamp_Ms(DateTime time)
             => (time.ToUniversalTime().Ticks - 621355968000000000) / 10000;
 
-        public static T Deserialize<T>(this in JsonElement element, JsonSerializerOptions options = null)
+        public static T Deserialize<T>(this in JsonElement element, JsonSerializerOptions? options = null)
         {
             var jsonDocument = JsonDeserialization.JsonDocumentField.GetValue(element);
-            ReadOnlyMemory<byte> bytes = (ReadOnlyMemory<byte>)JsonDeserialization.JsonDocumentUtf8JsonField.GetValue(jsonDocument);
-            return (T)JsonSerializer.Deserialize(bytes.Span, typeof(T), options);
+            ReadOnlyMemory<byte> bytes = (ReadOnlyMemory<byte>)JsonDeserialization.JsonDocumentUtf8JsonField.GetValue(jsonDocument)!;
+            return (T)JsonSerializer.Deserialize(bytes.Span, typeof(T), options)!;
         }
 
         private static class JsonDeserialization
         {
-            public static readonly FieldInfo JsonDocumentField = typeof(JsonElement).GetField("_parent", BindingFlags.NonPublic | BindingFlags.Instance);
-            public static readonly FieldInfo JsonDocumentUtf8JsonField = typeof(JsonDocument).GetField("_utf8Json", BindingFlags.NonPublic | BindingFlags.Instance);
+            public static readonly FieldInfo JsonDocumentField = typeof(JsonElement).GetField("_parent", BindingFlags.NonPublic | BindingFlags.Instance)!;
+            public static readonly FieldInfo JsonDocumentUtf8JsonField = typeof(JsonDocument).GetField("_utf8Json", BindingFlags.NonPublic | BindingFlags.Instance)!;
         }
     }
 }

--- a/Mirai-CSharp/Utility/WebSocketExtensions.cs
+++ b/Mirai-CSharp/Utility/WebSocketExtensions.cs
@@ -2,6 +2,7 @@
 using System.IO;
 using System.Net.Sockets;
 using System.Net.WebSockets;
+using System.Runtime.InteropServices;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -9,6 +10,28 @@ namespace Mirai_CSharp.Utility
 {
     public static class WebSocketExtensions
     {
+#if NETSTANDARD2_0
+        public static async ValueTask ReceiveFullyAsync(this WebSocket ws, Memory<byte> buffer, CancellationToken token = default)
+        {
+            MemoryMarshal.TryGetArray(buffer, out ArraySegment<byte> segment);
+            while (true)
+            {
+                WebSocketReceiveResult result = await ws.ReceiveAsync(segment, token);
+                if (result.Count < buffer.Length)
+                {
+                    if (result.EndOfMessage)
+                    {
+                        throw new EndOfStreamException();
+                    }
+                    buffer = buffer.Slice(result.Count);
+                }
+                else
+                {
+                    return;
+                }
+            }
+        }
+#else
         public static async ValueTask ReceiveFullyAsync(this WebSocket ws, Memory<byte> buffer, CancellationToken token = default)
         {
             while (true)
@@ -28,7 +51,35 @@ namespace Mirai_CSharp.Utility
                 }
             }
         }
+#endif
 
+#if NETSTANDARD2_0
+        public static async ValueTask<MemoryStream> ReceiveFullyAsync(this WebSocket webSocket, CancellationToken token = default)
+        {
+            byte[] buffer = new byte[1024];
+            ArraySegment<byte> segment = new ArraySegment<byte>(buffer);
+            MemoryStream ms = new MemoryStream(1024);
+            try
+            {
+                WebSocketReceiveResult result;
+                while (!(result = await webSocket.ReceiveAsync(segment, token)).EndOfMessage)
+                {
+                    ms.Write(buffer, 0, result.Count);
+                }
+                if (result.MessageType == WebSocketMessageType.Close && ms.Length == 0)
+                {
+                    throw new WebSocketException(10054);
+                }
+                ms.Write(buffer, 0, result.Count);
+                return ms;
+            }
+            catch
+            {
+                ms.Dispose();
+                throw;
+            }
+        }
+#else
         public static async ValueTask<MemoryStream> ReceiveFullyAsync(this WebSocket webSocket, CancellationToken token = default)
         {
             byte[] buffer = new byte[1024];
@@ -53,5 +104,6 @@ namespace Mirai_CSharp.Utility
                 throw;
             }
         }
+#endif
     }
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@
 #### 从 nuget 上获取 **Mirai-CSharp** 即可
 
 ### 注意事项  
-#### 本项目使用 `C# 8.0` 编写, 意味着你需要至少`.NET Core 3.0` 或 `.NET Standard 2.1`才能使用本项目, 其中所有的api均为**异步**方法  
+#### 本项目使用`C# 8.0`编写, 你需要至少`.NET Core 2.0` 或 `.NET Framework 4.6.1`才能使用本项目, 其中所有的api均为**异步**方法  
+#### 使用.NET Standard 2.0的用户无法使用`Plugin\Interfaces`下的所有接口, 请自行实现`IPlugin<TEventArgs>`接口
 
 ### 一些例子  
 - [配置Session](https://github.com/Executor-Cheng/Mirai-CSharp/tree/master/Mirai-CSharp.Example/Program.cs)  


### PR DESCRIPTION
fix #1 
修复了每次断开连接时错误地释放已注册的Plugin和已绑定的事件。
尝试性支持.NET Standard 2.0框架。
添加Nullable支持。
更改所有Exception的构造调用层次。
修改Invoking方法, 只关心插件是否实现了对应的IPlugin<TEventArgs>接口。
使Session的异步连接方法线程安全。