### PR TITLE
更新到v1.0.1.7

### DIFF
--- a/Mirai-CSharp/Mirai-CSharp.csproj
+++ b/Mirai-CSharp/Mirai-CSharp.csproj
@@ -5,9 +5,9 @@
     <RootNamespace>Mirai_CSharp</RootNamespace>
     <OutputType>Library</OutputType>
     <NoWin32Manifest>true</NoWin32Manifest>
-    <Version>1.0.1.6</Version>
-    <AssemblyVersion>1.0.1.6</AssemblyVersion>
-    <FileVersion>1.0.1.6</FileVersion>
+    <Version>1.0.1.7</Version>
+    <AssemblyVersion>1.0.1.7</AssemblyVersion>
+    <FileVersion>1.0.1.7</FileVersion>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <Authors>Executor</Authors>

--- a/Mirai-CSharp/Models/EventArgs/NewApplyEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/NewApplyEventArgs.cs
@@ -32,10 +32,10 @@ namespace Mirai_CSharp.Models
         public long EventId { get; set; }
 
         [JsonPropertyName("fromId")]
-        public long FromGroup { get; set; }
+        public long FromQQ { get; set; }
 
         [JsonPropertyName("groupId")]
-        public long FromQQ { get; set; }
+        public long FromGroup { get; set; }
 
         [JsonPropertyName("nick")]
         public string NickName { get; set; } = null!;

--- a/Mirai-CSharp/Utility/JsonConverters/IMessageBaseArrayConverter.cs
+++ b/Mirai-CSharp/Utility/JsonConverters/IMessageBaseArrayConverter.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 
+#pragma warning disable CS0618 // 类型或成员已过时
 namespace Mirai_CSharp.Utility.JsonConverters
 {
     public class IMessageBaseArrayConverter : JsonConverter<IMessageBase[]>


### PR DESCRIPTION
fix #5 
禁用IMessageBaseArrayConverter.cs内的CS0618。