### PR TITLE
更新到v1.0.1.8

### DIFF
--- a/Mirai-CSharp.Example/ExamplePlugin.Disconnected.cs
+++ b/Mirai-CSharp.Example/ExamplePlugin.Disconnected.cs
@@ -1,0 +1,28 @@
+﻿using Mirai_CSharp.Models;
+using System;
+using System.Threading.Tasks;
+
+#pragma warning disable CA1031 // Do not catch general exception types
+namespace Mirai_CSharp.Example
+{
+    public partial class ExamplePlugin
+    {
+        public async Task<bool> Disconnected(MiraiHttpSession session, IDisconnectedEventArgs e)
+        {
+            // e.Exception: 引发掉线的响应异常, 按需处理
+            MiraiHttpSessionOptions options = new MiraiHttpSessionOptions("127.0.0.1", 33111, "8d726307dd7b468d8550a95f236444f7");
+            while (true)
+            {
+                try
+                {
+                    await session.ConnectAsync(options, 0); // 连到成功为止, QQ号自填, 你也可以另行处理重连的 behaviour
+                    return true;
+                }
+                catch (Exception)
+                {
+                    await Task.Delay(1000);
+                }
+            }
+        }
+    }
+}

--- a/Mirai-CSharp.Example/ExamplePlugin.FriendMessage.cs
+++ b/Mirai-CSharp.Example/ExamplePlugin.FriendMessage.cs
@@ -12,8 +12,20 @@ namespace Mirai_CSharp.Example
             {
                 new PlainMessage($"收到了来自{e.Sender.Name}({e.Sender.Remark})[{e.Sender.Id}]的私聊消息:{string.Join(null, (IEnumerable<IMessageBase>)e.Chain)}")
                 //                          /   好友昵称  /  /    好友备注    /  /  好友QQ号  /                                                        / 消息链 /
+                // 你还可以在这里边加入更多的 IMessageBase
             };
             await session.SendFriendMessageAsync(e.Sender.Id, chain); // 向消息来源好友异步发送由以上chain表示的消息
+            return false; // 不阻断消息传递。如需阻断请返回true
+        }
+
+#pragma warning disable CA1822 // Mark members as static // 示例方法禁用Information
+#pragma warning disable IDE0059 // 不需要赋值 // 禁用+1
+        public async Task<bool> FriendMessage2(MiraiHttpSession session, IFriendMessageEventArgs e)
+        {
+            IMessageBase plain1 = new PlainMessage($"收到了来自{e.Sender.Name}({e.Sender.Remark})[{e.Sender.Id}]的私聊消息:{string.Join(null, (IEnumerable<IMessageBase>)e.Chain)}");
+            //                                                /   好友昵称  /  /    好友备注    /  /  好友QQ号  /                                                        / 消息链 /
+            IMessageBase plain2 = new PlainMessage("嘤嘤嘤"); // 在下边的 SendFriendMessageAsync, 你可以串起n个 IMessageBase
+            await session.SendFriendMessageAsync(e.Sender.Id, plain1/*, plain2, /* etc... */); // 向消息来源好友异步发送由以上chain表示的消息
             return false; // 不阻断消息传递。如需阻断请返回true
         }
     }

--- a/Mirai-CSharp.Example/ExamplePlugin.GroupMessage.cs
+++ b/Mirai-CSharp.Example/ExamplePlugin.GroupMessage.cs
@@ -13,8 +13,20 @@ namespace Mirai_CSharp.Example
             {
                 new PlainMessage($"收到了来自{e.Sender.Name}[{e.Sender.Id}]{{{e.Sender.Permission}}}的群消息:{string.Join(null, (IEnumerable<IMessageBase>)e.Chain)}")
                 //                          / 发送者群名片 /  / 发送者QQ号 /   /   发送者在群内权限   /                                                       / 消息链 /
+                // 你还可以在这里边加入更多的 IMessageBase
             };
             await session.SendGroupMessageAsync(e.Sender.Group.Id, chain); // 向消息来源群异步发送由以上chain表示的消息
+            return false; // 不阻断消息传递。如需阻断请返回true
+        }
+
+#pragma warning disable CA1822 // Mark members as static // 示例方法禁用Information
+#pragma warning disable IDE0059 // 不需要赋值 // 禁用+1
+        public async Task<bool> GroupMessage2(MiraiHttpSession session, IGroupMessageEventArgs e)
+        {
+            IMessageBase plain1 = new PlainMessage($"收到了来自{e.Sender.Name}[{e.Sender.Id}]{{{e.Sender.Permission}}}的群消息:{string.Join(null, (IEnumerable<IMessageBase>)e.Chain)}");
+            //                                                / 发送者群名片 /  / 发送者QQ号 /   /   发送者在群内权限   /                                                       / 消息链 /
+            IMessageBase plain2 = new PlainMessage("QAQ"); // 在下边的 SendGroupMessageAsync, 你可以串起n个 IMessageBase
+            await session.SendGroupMessageAsync(e.Sender.Group.Id, plain1/*, plain2, /* etc... */); // 向消息来源群异步发送由以上chain表示的消息
             return false; // 不阻断消息传递。如需阻断请返回true
         }
     }

--- a/Mirai-CSharp.Example/ExamplePlugin.cs
+++ b/Mirai-CSharp.Example/ExamplePlugin.cs
@@ -3,11 +3,12 @@
 namespace Mirai_CSharp.Example
 {
     public partial class ExamplePlugin : IFriendMessage, // 你想处理什么事件就实现什么事件对应的接口
-                                 IGroupMessage, 
+                                 IGroupMessage,
                                  INewFriendApply,
                                  IGroupApply,
-                                 IBotInvitedJoinGroup
+                                 IBotInvitedJoinGroup,
+                                 IDisconnected
     {
-
+        
     }
 }

--- a/Mirai-CSharp.Example/Program.cs
+++ b/Mirai-CSharp.Example/Program.cs
@@ -9,6 +9,7 @@ namespace Mirai_CSharp.Example
         public static async Task Main()
         {
             // 把你要连接到的 mirai-api-http 所需的主机名/IP, 端口 和 AuthKey 全部填好
+            // !! 最好不要用我例子里边的 key 和 端口, 请自己生成一个, 比如 System.Guid.NewGuid().ToString("n") !!
             MiraiHttpSessionOptions options = new MiraiHttpSessionOptions("127.0.0.1", 33111, "8d726307dd7b468d8550a95f236444f7");
             // session 使用 DisposeAsync 模式, 所以使用 await using 自动调用 DisposeAsync 方法。
             // 你也可以不在这里 await using, 不过使用完 session 后请务必调用 DisposeAsync 方法

--- a/Mirai-CSharp/Mirai-CSharp.csproj
+++ b/Mirai-CSharp/Mirai-CSharp.csproj
@@ -5,9 +5,9 @@
     <RootNamespace>Mirai_CSharp</RootNamespace>
     <OutputType>Library</OutputType>
     <NoWin32Manifest>true</NoWin32Manifest>
-    <Version>1.0.1.7</Version>
-    <AssemblyVersion>1.0.1.7</AssemblyVersion>
-    <FileVersion>1.0.1.7</FileVersion>
+    <Version>1.0.1.8</Version>
+    <AssemblyVersion>1.0.1.8</AssemblyVersion>
+    <FileVersion>1.0.1.8</FileVersion>
     <Nullable>enable</Nullable>
     <LangVersion>preview</LangVersion>
     <Authors>Executor</Authors>

--- a/Mirai-CSharp/Session/MiraiHttpSession.Message.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Message.cs
@@ -65,6 +65,22 @@ namespace Mirai_CSharp
         /// <summary>
         /// 异步发送好友消息
         /// </summary>
+        /// <remarks>
+        /// 本方法不会引用回复, 要引用回复, 请调用 <see cref="SendFriendMessageAsync(long, IMessageBase[], int?)"/>
+        /// </remarks>
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="InvalidOperationException"/>
+        /// <exception cref="MessageTooLongException"/>
+        /// <exception cref="TargetNotFoundException"/>
+        /// <param name="qqNumber">目标QQ号</param>
+        /// <param name="chain">消息链数组。不可为 <see langword="null"/> 或空数组</param>
+        public Task<int> SendFriendMessageAsync(long qqNumber, params IMessageBase[] chain)
+        {
+            return CommonSendMessageAsync("sendFriendMessage", qqNumber, null, chain, null);
+        }
+        /// <summary>
+        /// 异步发送好友消息
+        /// </summary>
         /// <exception cref="ArgumentException"/>
         /// <exception cref="InvalidOperationException"/>
         /// <exception cref="MessageTooLongException"/>
@@ -75,6 +91,23 @@ namespace Mirai_CSharp
         public Task<int> SendFriendMessageAsync(long qqNumber, IMessageBase[] chain, int? quoteMsgId = null)
         {
             return CommonSendMessageAsync("sendFriendMessage", qqNumber, null, chain, quoteMsgId);
+        }
+        /// <summary>
+        /// 异步发送临时消息
+        /// </summary>
+        /// <remarks>
+        /// 本方法不会引用回复, 要引用回复, 请调用 <see cref="SendTempMessageAsync(long, long, IMessageBase[], int?)"/>
+        /// </remarks>
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="InvalidOperationException"/>
+        /// <exception cref="MessageTooLongException"/>
+        /// <exception cref="TargetNotFoundException"/>
+        /// <param name="qqNumber">目标QQ号</param>
+        /// <param name="fromGroup">目标所在的群号</param>
+        /// <param name="chain">消息链数组。不可为 <see langword="null"/> 或空数组</param>
+        public Task<int> SendTempMessageAsync(long qqNumber, long fromGroup, params IMessageBase[] chain)
+        {
+            return CommonSendMessageAsync("sendTempMessage", qqNumber, fromGroup, chain, null);
         }
         /// <summary>
         /// 异步发送临时消息
@@ -90,6 +123,23 @@ namespace Mirai_CSharp
         public Task<int> SendTempMessageAsync(long qqNumber, long fromGroup, IMessageBase[] chain, int? quoteMsgId = null)
         {
             return CommonSendMessageAsync("sendTempMessage", qqNumber, fromGroup, chain, quoteMsgId);
+        }
+        /// <summary>
+        /// 异步发送群消息
+        /// </summary>
+        /// <remarks>
+        /// 本方法不会引用回复, 要引用回复, 请调用 <see cref="SendGroupMessageAsync(long, IMessageBase[], int?)"/>
+        /// </remarks>
+        /// <exception cref="ArgumentException"/>
+        /// <exception cref="BotMutedException"/>
+        /// <exception cref="InvalidOperationException"/>
+        /// <exception cref="MessageTooLongException"/>
+        /// <exception cref="TargetNotFoundException"/>
+        /// <param name="groupNumber">目标群号</param>
+        /// <param name="chain">消息链数组。不可为 <see langword="null"/> 或空数组</param>
+        public Task<int> SendGroupMessageAsync(long groupNumber, params IMessageBase[] chain)
+        {
+            return CommonSendMessageAsync("sendGroupMessage", null, groupNumber, chain, null);
         }
         /// <summary>
         /// 异步发送群消息

--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@
 - [处理入群申请](https://github.com/Executor-Cheng/Mirai-CSharp/blob/master/Mirai-CSharp.Example/ExamplePlugin.GroupApply.cs)  
 - [处理Bot受邀入群申请](https://github.com/Executor-Cheng/Mirai-CSharp/blob/master/Mirai-CSharp.Example/ExamplePlugin.BotInvitedJoinGroup.cs)  
 - [发送图片](https://github.com/Executor-Cheng/Mirai-CSharp/blob/master/Mirai-CSharp.Example/ExamplePlugin.SendPicture.cs)  
+- [处理Session掉线](https://github.com/Executor-Cheng/Mirai-CSharp/blob/master/Mirai-CSharp.Example/ExamplePlugin.Disconnected.cs)  


### PR DESCRIPTION
为`MiraiHttpSession`中的`SendFriendMessageAsync`, `SendGroupMessageAsync`, `SendTempMessageAsync`添加更简单的重载。
为Example项目添加处理掉线的实例, 并对新增的三个重载添加例子。