### PR TITLE
更新到1.0.2.2-preview-3

### DIFF
--- a/Mirai-CSharp.Example/Mirai-CSharp.Example.csproj
+++ b/Mirai-CSharp.Example/Mirai-CSharp.Example.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
   
   <ItemGroup>
-    <PackageReference Include="Mirai-CSharp" Version="1.0.2.0" />  
+    <PackageReference Include="Mirai-CSharp" Version="1.0.2.2-preview.3" />  
   </ItemGroup>
   
 </Project>

--- a/Mirai-CSharp/Mirai-CSharp.csproj
+++ b/Mirai-CSharp/Mirai-CSharp.csproj
@@ -8,7 +8,7 @@
     <Version>1.0.2.2</Version>
     <AssemblyVersion>1.0.2.2</AssemblyVersion>
     <FileVersion>1.0.2.2</FileVersion>
-    <PackageVersion>1.0.2.2-preview.2</PackageVersion>
+    <PackageVersion>1.0.2.2-preview.3</PackageVersion>
     <Nullable>enable</Nullable>
     <LangVersion>9.0</LangVersion>
     <Authors>Executor</Authors>

--- a/Mirai-CSharp/Session/MiraiHttpSession.Authentication.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.Authentication.cs
@@ -159,7 +159,10 @@ namespace Mirai_CSharp
             };
             try
             {
-                await session.Client.PostAsJsonAsync($"{session.Options.BaseUrl}/release", payload, token).AsApiRespAsync(token);
+                if (session.Options != null)
+                {
+                    await session.Client.PostAsJsonAsync($"{session.Options.BaseUrl}/release", payload, token).AsApiRespAsync(token);
+                }
             }
             finally
             {

--- a/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
@@ -72,7 +72,6 @@ namespace Mirai_CSharp
         {
             return CommonSendImageAsync(null, groupNumber, urls);
         }
-
         /// <summary>
         /// 内部使用
         /// </summary>
@@ -80,16 +79,35 @@ namespace Mirai_CSharp
         /// <param name="type">目标类型</param>
         /// <param name="imgStream">图片流</param>
         /// <remarks>
-        /// 注意: 当 mirai-api-http 的版本小于等于v1.7.0时, 本方法返回的将是一个只有 Url 有值的 <see cref="ImageMessage"/>
+        /// 当 mirai-api-http 的版本小于等于v1.7.0时, 本方法返回的将是一个只有 Url 有值的 <see cref="ImageMessage"/>
+        /// <para/>
+        /// <paramref name="imgStream"/> 会被读取至末尾
         /// </remarks>
         /// <returns>一个 <see cref="ImageMessage"/> 实例, 可用于以后的消息发送</returns>
-        private static Task<ImageMessage> InternalUploadPictureAsync(InternalSessionInfo session, UploadTarget type, Stream imgStream)
+        private static async Task<ImageMessage> InternalUploadPictureAsync(InternalSessionInfo session, UploadTarget type, Stream imgStream)
         {
             if (session.ApiVersion <= new Version(1, 7, 0))
             {
                 Guid guid = Guid.NewGuid();
-                ImageHttpListener.RegisterImage(guid, imgStream);
-                return Task.FromResult(new ImageMessage(null, $"http://127.0.0.1:{ImageHttpListener.Port}/fetch?guid={guid:n}", null));
+                MemoryStream ms = new MemoryStream(8192); // 无论如何都做一份copy
+                await imgStream.CopyToAsync(ms);
+                ImageHttpListener.RegisterImage(guid, ms);
+                return new ImageMessage(null, $"http://127.0.0.1:{ImageHttpListener.Port}/fetch?guid={guid:n}", null);
+            }
+            Stream? internalStream = null;
+            bool internalCreated = false;
+            long pervious = 0;
+            if (!imgStream.CanSeek || imgStream.CanTimeout) // 对于 CanTimeOut 的 imgStream, 或者无法Seek的, 一律假定其读取行为是阻塞的
+                                                            // 为其创建一个内部缓存先行异步读取
+            {
+                internalStream = new MemoryStream(8192);
+                internalCreated = true;
+                await imgStream.CopyToAsync(internalStream);
+            }
+            else // 否则不创建副本, 避免多余的堆分配
+            {
+                internalStream = imgStream;
+                pervious = imgStream.Position;
             }
             HttpContent sessionKeyContent = new StringContent(session.SessionKey);
             sessionKeyContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
@@ -102,7 +120,7 @@ namespace Mirai_CSharp
                 Name = "type"
             };
             string format;
-            using (Image img = Image.FromStream(imgStream))
+            using (Image img = Image.FromStream(internalStream)) // 已经把数据读到非托管内存里边了, 就不用管input的死活了
             {
                 format = img.RawFormat.ToString();
                 switch (format)
@@ -116,17 +134,30 @@ namespace Mirai_CSharp
                         }
                     default: // 不是以上三种类型的图片就强转为Png
                         {
-                            MemoryStream ms = new MemoryStream();
-                            img.Save(ms, ImageFormat.Png);
-                            imgStream.Dispose();
-                            imgStream = ms;
+                            if (!internalCreated)
+                            {
+                                internalStream = new MemoryStream(8192);
+                                internalCreated = true;
+                            }
+                            else
+                            {
+                                internalStream.Seek(0, SeekOrigin.Begin);
+                            }
+                            img.Save(internalStream, ImageFormat.Png);
                             format = "png";
                             break;
                         }
                 }
             }
-            imgStream.Seek(0, SeekOrigin.Begin);
-            HttpContent imageContent = new StreamContent(imgStream);
+            if (internalCreated)
+            {
+                internalStream.Seek(0, SeekOrigin.Begin);
+            }
+            else // internalStream == imgStream
+            {
+                internalStream.Seek(pervious - internalStream.Position, SeekOrigin.Current);
+            }
+            HttpContent imageContent = new StreamContent(internalStream);
             imageContent.Headers.ContentDisposition = new ContentDispositionHeaderValue("form-data")
             {
                 Name = "img",
@@ -135,14 +166,15 @@ namespace Mirai_CSharp
             imageContent.Headers.ContentType = new MediaTypeHeaderValue("image/" + format);
             HttpContent[] contents = new HttpContent[]
             {
-                sessionKeyContent,
-                typeContent,
-                imageContent
+                    sessionKeyContent,
+                    typeContent,
+                    imageContent
             };
-            return session.Client.PostAsync($"{session.Options.BaseUrl}/uploadImage", contents, session.Token)
+            return await session.Client.PostAsync($"{session.Options.BaseUrl}/uploadImage", contents, session.Token)
                 .AsApiRespAsync<ImageMessage>(session.Token)
                 .ContinueWith(t => t.IsFaulted && t.Exception!.InnerException is JsonException ? throw new NotSupportedException("当前版本的mirai-api-http无法发送图片。") : t, TaskContinuationOptions.ExecuteSynchronously).Unwrap();
             //  ^-- 处理 JsonException 到 NotSupportedException, https://github.com/mamoe/mirai-api-http/issues/85
+            // internalStream 是 MemoryStream, 内部为全托管字段不需要 Dispose
         }
         /// <summary>
         /// 异步上传图片


### PR DESCRIPTION
重做InternalUploadPictureAsync以避免错误读取imgStream。
解决InternalReleaseAsync可能出现使用null的session.Options情况。