### PR TITLE
改为使用SkiaSharp

### DIFF
--- a/Mirai-CSharp/Mirai-CSharp.csproj
+++ b/Mirai-CSharp/Mirai-CSharp.csproj
@@ -45,12 +45,8 @@
     <None Remove="Mirai-CSharp.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0-preview.5.20278.1" />
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0'">


### PR DESCRIPTION
[关于 System.Drawing 的注解](https://docs.microsoft.com/zh-cn/dotnet/api/system.drawing?view=net-5.0#remarks)中建议不使用 System.Drawing 命名空间，故改为 SkiaSharp。