### PR TITLE
图像转码改为使用SkiaSharp

### DIFF
--- a/Mirai-CSharp/Mirai-CSharp.csproj
+++ b/Mirai-CSharp/Mirai-CSharp.csproj
@@ -46,12 +46,8 @@
     <None Remove="Mirai-CSharp.xml" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'net5.0'">
-    <PackageReference Include="System.Drawing.Common" Version="4.7.0" />
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(TargetFramework)' == 'net5.0'">
-    <PackageReference Include="System.Drawing.Common" Version="5.0.0" />
+  <ItemGroup>
+    <PackageReference Include="SkiaSharp" Version="2.80.2" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1' Or '$(TargetFramework)' == 'netstandard2.0'">

--- a/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
@@ -120,10 +120,8 @@ namespace Mirai_CSharp
                 Name = "type"
             };
             string format;
-            using MemoryStream codecMemoryStream = new MemoryStream();
-            await internalStream.CopyToAsync(codecMemoryStream);
-            codecMemoryStream.Seek(0, SeekOrigin.Begin);
-            using (SKCodec codec = SKCodec.Create(codecMemoryStream)) // 已经把数据读到非托管内存里边了, 就不用管input的死活了
+            using SKManagedStream skstream = new SKManagedStream(internalStream, false);
+            using (SKCodec codec = SKCodec.Create(skstream)) // 已经把数据读到非托管内存里边了, 就不用管input的死活了
             {
                 var skformat = codec.EncodedFormat;
                 format = skformat.ToString().ToLower();

--- a/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
@@ -3,13 +3,12 @@ using Mirai_CSharp.Extensions;
 using Mirai_CSharp.Models;
 using Mirai_CSharp.Utility;
 using System;
-using System.Drawing;
-using System.Drawing.Imaging;
 using System.IO;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text.Json;
 using System.Threading.Tasks;
+using SkiaSharp;
 #if NET5_0
 using System.Net.Http.Json;
 #endif
@@ -121,30 +120,36 @@ namespace Mirai_CSharp
                 Name = "type"
             };
             string format;
-            using (Image img = Image.FromStream(internalStream)) // 已经把数据读到非托管内存里边了, 就不用管input的死活了
+            using MemoryStream codecMemoryStream = new MemoryStream();
+            await internalStream.CopyToAsync(codecMemoryStream);
+            codecMemoryStream.Seek(0, SeekOrigin.Begin);
+            using (SKCodec codec = SKCodec.Create(codecMemoryStream)) // 已经把数据读到非托管内存里边了, 就不用管input的死活了
             {
-                format = img.RawFormat.ToString();
-                switch (format)
+                var skformat = codec.EncodedFormat;
+                format = skformat.ToString().ToLower();
+                switch (skformat)
                 {
-                    case nameof(ImageFormat.Jpeg):
-                    case nameof(ImageFormat.Png):
-                    case nameof(ImageFormat.Gif):
-                        {
-                            format = format.ToLower();
-                            break;
-                        }
-                    default: // 不是以上三种类型的图片就强转为Png
+                    case SKEncodedImageFormat.Gif:
+                    case SKEncodedImageFormat.Jpeg:
+                    case SKEncodedImageFormat.Png:
+                        break;
+                    default:
                         {
                             if (!internalCreated)
                             {
-                                internalStream = new MemoryStream(8192);
+                                internalStream.Seek(pervious - internalStream.Position, SeekOrigin.Current);
                                 internalCreated = true;
                             }
                             else
                             {
                                 internalStream.Seek(0, SeekOrigin.Begin);
                             }
-                            img.Save(internalStream, ImageFormat.Png);
+                            using (SKBitmap bitmap = SKBitmap.Decode(internalStream))
+                            {
+                                MemoryStream ms = new MemoryStream();
+                                bitmap.Encode(ms, SKEncodedImageFormat.Png, 100);
+                                internalStream = ms;
+                            }
                             format = "png";
                             break;
                         }

--- a/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
+++ b/Mirai-CSharp/Session/MiraiHttpSession.SendImage.cs
@@ -133,20 +133,19 @@ namespace Mirai_CSharp
                         break;
                     default:
                         {
-                            if (!internalCreated)
+                            skstream.Seek(0);
+                            using (SKBitmap bitmap = SKBitmap.Decode(skstream))
                             {
-                                internalStream.Seek(pervious - internalStream.Position, SeekOrigin.Current);
-                                internalCreated = true;
-                            }
-                            else
-                            {
-                                internalStream.Seek(0, SeekOrigin.Begin);
-                            }
-                            using (SKBitmap bitmap = SKBitmap.Decode(internalStream))
-                            {
-                                MemoryStream ms = new MemoryStream();
-                                bitmap.Encode(ms, SKEncodedImageFormat.Png, 100);
-                                internalStream = ms;
+                                if (!internalCreated)
+                                {
+                                    internalStream = new MemoryStream(8192);
+                                    internalCreated = true;
+                                }
+                                else
+                                {
+                                    internalStream.Seek(0, SeekOrigin.Begin);
+                                }
+                                bitmap.Encode(internalStream, SKEncodedImageFormat.Png, 100);
                             }
                             format = "png";
                             break;


### PR DESCRIPTION
[关于 System.Drawing 的注解](https://docs.microsoft.com/zh-cn/dotnet/api/system.drawing?view=net-5.0#remarks)中建议不使用 System.Drawing 命名空间，故改为 SkiaSharp。