### PR TITLE
更新至v2.0.0-rc.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -12,7 +12,7 @@
         <Version>2.0.0.0</Version>
         <AssemblyVersion>2.0.0.0</AssemblyVersion>
         <FileVersion>2.0.0.0</FileVersion>
-        <PackageVersion>2.0.0.0-rc.1</PackageVersion>
+        <PackageVersion>2.0.0.0-rc.2</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.HttpApi/Exceptions/UnknownResponseException.cs
+++ b/Mirai-CSharp.HttpApi/Exceptions/UnknownResponseException.cs
@@ -1,5 +1,8 @@
 using System;
 using System.Text.Json;
+#if NET6_0_OR_GREATER
+using System.Text.Json.Nodes;
+#endif
 
 namespace Mirai.CSharp.HttpApi.Exceptions
 {
@@ -18,6 +21,12 @@ namespace Mirai.CSharp.HttpApi.Exceptions
         public UnknownResponseException(in JsonElement root, Exception? innerException) : this(root.GetRawText(), innerException) { }
 
         public UnknownResponseException(in JsonElement root, string? message, Exception? innerException) : this(root.GetRawText(), message, innerException) { }
+
+#if NET6_0_OR_GREATER
+        public UnknownResponseException(JsonNode node) : this(node.ToJsonString()) { }
+
+        public UnknownResponseException(JsonNode node, string message) : this(node.ToJsonString(), message) { }
+#endif
 
         public UnknownResponseException(string? response) : this(response, DefaultMessage, null) { }
 

--- a/Mirai-CSharp.HttpApi/Extensions/ApiResponseExtensions.cs
+++ b/Mirai-CSharp.HttpApi/Extensions/ApiResponseExtensions.cs
@@ -7,8 +7,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Mirai.CSharp.Exceptions;
 using Mirai.CSharp.HttpApi.Exceptions;
-using Mirai.CSharp.HttpApi.Session;
+#if !NET6_0
 using Mirai.CSharp.HttpApi.Utility;
+#endif
 
 namespace Mirai.CSharp.HttpApi.Extensions
 {
@@ -93,11 +94,33 @@ namespace Mirai.CSharp.HttpApi.Extensions
 
         public static async Task<TResult> AsApiRespAsync<TResult, TImpl>(this Task<HttpResponseMessage> responseTask, CancellationToken token = default) where TImpl : TResult
         {
-            using var j = await responseTask.GetJsonAsync(token);
+            //using var j = await responseTask.GetJsonAsync(token);
+            string json = await responseTask.GetStringAsync(token);
+            using var j = JsonDocument.Parse(json);
             var root = j.RootElement;
             if (root.CheckApiRespCode(out var code))
             {
                 return root.Deserialize<TImpl>()!;
+            }
+            throw GetCommonException(code!.Value, in root);
+        }
+
+        public static Task<TResult> AsApiRespV2Async<TResult>(this Task<HttpResponseMessage> responseTask, CancellationToken token = default)
+        {
+            return responseTask.AsApiRespV2Async<TResult, TResult>(token);
+        }
+
+        public static async Task<TResult> AsApiRespV2Async<TResult, TImpl>(this Task<HttpResponseMessage> responseTask, CancellationToken token = default) where TImpl : TResult
+        {
+            using var j = await responseTask.GetJsonAsync(token);
+            var root = j.RootElement;
+            if (root.CheckApiRespCode(out var code))
+            {
+                if (root.TryGetProperty("data", out JsonElement data))
+                {
+                    return data.Deserialize<TImpl>()!;
+                }
+                return root.Deserialize<TImpl>()!; // 向前兼容, 不确定 mirai-api-http v1.x 的行为如何
             }
             throw GetCommonException(code!.Value, in root);
         }

--- a/Mirai-CSharp.HttpApi/Extensions/ApiResponseExtensions.cs
+++ b/Mirai-CSharp.HttpApi/Extensions/ApiResponseExtensions.cs
@@ -67,13 +67,10 @@ namespace Mirai.CSharp.HttpApi.Extensions
             code = codeToken.GetInt32();
             return false;
         }
-#if NETSTANDARD2_0
-        public static void EnsureApiRespCode(this JsonElement root, out int? code)
-#else
-        public static void EnsureApiRespCode(this JsonElement root, [NotNullWhen(false)] out int? code)
-#endif
+
+        public static void EnsureApiRespCode(this JsonElement root)
         {
-            if (!root.CheckApiRespCode(out code))
+            if (!root.CheckApiRespCode(out int? code))
             {
                 throw GetCommonException(code!.Value, in root);
             }

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotJoinedGroupEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotJoinedGroupEventArgs.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Text.Json.Serialization;
 using Mirai.CSharp.HttpApi.Parsers.Attributes;
+using Mirai.CSharp.HttpApi.Utility.JsonConverters;
 using ISharedBotJoinedGroupEventArgs = Mirai.CSharp.Models.EventArgs.IBotJoinedGroupEventArgs<System.Text.Json.JsonElement>;
+#if NETSTANDARD2_0
+using ISharedInviterEventArgs = Mirai.CSharp.Models.EventArgs.IInviterEventArgs;
+using ISharedGroupMemberInfo = Mirai.CSharp.Models.IGroupMemberInfo;
+#endif
 
 namespace Mirai.CSharp.HttpApi.Models.EventArgs
 {
@@ -8,13 +14,18 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     /// 提供Bot加入了一个新群相关信息的接口。继承自 <see cref="ISharedBotJoinedGroupEventArgs"/> 和 <see cref="IGroupEventArgs"/>
     /// </summary>
     [MappableMiraiHttpMessageKey("BotJoinGroupEvent")]
-    public interface IBotJoinedGroupEventArgs : ISharedBotJoinedGroupEventArgs, IGroupEventArgs
+    public interface IBotJoinedGroupEventArgs : ISharedBotJoinedGroupEventArgs, IGroupEventArgs, IInviterEventArgs
     {
 
     }
 
     public class BotJoinedGroupEventArgs : GroupEventArgs, IBotJoinedGroupEventArgs
     {
+        /// <inheritdoc/>
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonPropertyName("invitor")]
+        public IGroupMemberInfo? Inviter { get; set; }
+
         [Obsolete("此类不应由用户主动创建实例。")]
         public BotJoinedGroupEventArgs()
         {
@@ -26,5 +37,12 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         {
 
         }
+
+#if NETSTANDARD2_0
+        /// <inheritdoc/>
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonPropertyName("invitor")]
+        ISharedGroupMemberInfo? ISharedInviterEventArgs.Inviter => Inviter;
+#endif
     }
 }

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotKickedOutEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotKickedOutEventArgs.cs
@@ -5,24 +5,24 @@ using ISharedBotKickedOutEventArgs = Mirai.CSharp.Models.EventArgs.IBotKickedOut
 namespace Mirai.CSharp.HttpApi.Models.EventArgs
 {
     /// <summary>
-    /// 提供Bot被踢出一个群相关信息的接口。继承自 <see cref="ISharedBotKickedOutEventArgs"/> 和 <see cref="IGroupEventArgs"/>
+    /// 提供Bot被踢出一个群相关信息的接口。继承自 <see cref="ISharedBotKickedOutEventArgs"/> 和 <see cref="IGroupOperatingEventArgs"/>
     /// </summary>
     [MappableMiraiHttpMessageKey("BotLeaveEventKick")]
-    public interface IBotKickedOutEventArgs : ISharedBotKickedOutEventArgs, IGroupEventArgs
+    public interface IBotKickedOutEventArgs : ISharedBotKickedOutEventArgs, IGroupOperatingEventArgs
     {
 
     }
 
-    public class BotKickedOutEventArgs : GroupEventArgs, IBotKickedOutEventArgs
+    public class BotKickedOutEventArgs : GroupOperatingEventArgs, IBotKickedOutEventArgs
     {
         [Obsolete("此类不应由用户主动创建实例。")]
         public BotKickedOutEventArgs()
         {
-
+            
         }
 
         [Obsolete("此类不应由用户主动创建实例。")]
-        public BotKickedOutEventArgs(GroupInfo group) : base(group)
+        public BotKickedOutEventArgs(IGroupInfo group, IGroupMemberInfo @operator) : base(group, @operator)
         {
 
         }

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotReloginEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotReloginEventArgs.cs
@@ -13,7 +13,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
     }
 
-    public class BotReloginEventArgs : BotEventArgs, IBotOnlineEventArgs
+    public class BotReloginEventArgs : BotEventArgs, IBotReloginEventArgs
     {
         [Obsolete("此类不应由用户主动创建实例。")]
         public BotReloginEventArgs()

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Friend/FriendEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Friend/FriendEventArgs.cs
@@ -22,7 +22,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class FriendEventArgs : MiraiHttpMessage, IFriendEventArgs
     {
         [JsonPropertyName("friend")]
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, ISharedFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, IFriendInfo>))]
         public IFriendInfo Friend { get; set; } = null!;
 
         protected FriendEventArgs()

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupEventArgs.cs
@@ -8,9 +8,11 @@ using ISharedGroupOperatingEventArgs = Mirai.CSharp.Models.EventArgs.IGroupOpera
 using ISharedJsonGroupEventArgs = Mirai.CSharp.Models.EventArgs.IGroupEventArgs<System.Text.Json.JsonElement>;
 using ISharedJsonMemberEventArgs = Mirai.CSharp.Models.EventArgs.IMemberEventArgs<System.Text.Json.JsonElement>;
 using ISharedJsonOperatorEventArgs = Mirai.CSharp.Models.EventArgs.IOperatorEventArgs<System.Text.Json.JsonElement>;
+using ISharedJsonInviterEventArgs = Mirai.CSharp.Models.EventArgs.IInviterEventArgs<System.Text.Json.JsonElement>;
 using ISharedMemberEventArgs = Mirai.CSharp.Models.EventArgs.IMemberEventArgs;
 using ISharedMemberOperatingEventArgs = Mirai.CSharp.Models.EventArgs.IMemberOperatingEventArgs;
 using ISharedOperatorEventArgs = Mirai.CSharp.Models.EventArgs.IOperatorEventArgs;
+using ISharedInviterEventArgs = Mirai.CSharp.Models.EventArgs.IInviterEventArgs;
 
 namespace Mirai.CSharp.HttpApi.Models.EventArgs
 {
@@ -104,7 +106,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if !NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
         [JsonPropertyName("operator")]
         ISharedGroupMemberInfo ISharedOperatorEventArgs.Operator => Operator;
 #endif
@@ -128,7 +130,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
         [JsonPropertyName("operator")]
         ISharedGroupMemberInfo ISharedOperatorEventArgs.Operator => Operator;
 #endif
@@ -196,5 +198,34 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         [JsonPropertyName("member")]
         ISharedGroupMemberInfo ISharedMemberEventArgs.Member => Member;
 #endif
+    }
+
+    /// <summary>
+    /// 提供邀请人相关信息的接口。继承自 <see cref="ISharedInviterEventArgs"/> 和 <see cref="IMiraiHttpMessage"/>
+    /// </summary>
+    public interface IInviterEventArgs : ISharedInviterEventArgs, IMiraiHttpMessage
+    {
+        /// <summary>
+        /// 邀请人信息
+        /// </summary>
+        /// <remarks>
+        /// 仅当 mirai-api-http 版本至少为 2.3.0 时, 此属性可能不为 <see langword="null"/>
+        /// </remarks>
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonPropertyName("invitor")]
+        new IGroupMemberInfo? Inviter { get; }
+
+#if !NETSTANDARD2_0
+        /// <inheritdoc/>
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonPropertyName("invitor")]
+        ISharedGroupMemberInfo? ISharedInviterEventArgs.Inviter => Inviter;
+#endif
+    }
+
+    /// <inheritdoc/>
+    public interface IInviterEventArgs<TRawdata> : IInviterEventArgs, ISharedJsonInviterEventArgs
+    {
+
     }
 }

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/Specialized/GroupMemberJoinedEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/Specialized/GroupMemberJoinedEventArgs.cs
@@ -1,6 +1,12 @@
 using System;
+using System.Text.Json.Serialization;
 using Mirai.CSharp.HttpApi.Parsers.Attributes;
+using Mirai.CSharp.HttpApi.Utility.JsonConverters;
 using ISharedGroupMemberJoinedEventArgs = Mirai.CSharp.Models.EventArgs.IGroupMemberJoinedEventArgs<System.Text.Json.JsonElement>;
+#if NETSTANDARD2_0
+using ISharedInviterEventArgs = Mirai.CSharp.Models.EventArgs.IInviterEventArgs;
+using ISharedGroupMemberInfo = Mirai.CSharp.Models.IGroupMemberInfo;
+#endif
 
 namespace Mirai.CSharp.HttpApi.Models.EventArgs
 {
@@ -8,13 +14,18 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     /// 提供新人入群相关信息的接口。继承自 <see cref="ISharedGroupMemberJoinedEventArgs"/> 和 <see cref="IMemberEventArgs"/>
     /// </summary>
     [MappableMiraiHttpMessageKey("MemberJoinEvent")]
-    public interface IGroupMemberJoinedEventArgs : ISharedGroupMemberJoinedEventArgs, IMemberEventArgs
+    public interface IGroupMemberJoinedEventArgs : ISharedGroupMemberJoinedEventArgs, IMemberEventArgs, IInviterEventArgs
     {
 
     }
 
     public class GroupMemberJoinedEventArgs : MemberEventArgs, IGroupMemberJoinedEventArgs
     {
+        /// <inheritdoc/>
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonPropertyName("invitor")]
+        public IGroupMemberInfo? Inviter { get; set; }
+
         [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberJoinedEventArgs()
         {
@@ -26,5 +37,12 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         {
 
         }
+
+#if NETSTANDARD2_0
+        /// <inheritdoc/>
+        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonPropertyName("invitor")]
+        ISharedGroupMemberInfo? ISharedInviterEventArgs.Inviter => Inviter;
+#endif
     }
 }

--- a/Mirai-CSharp.HttpApi/Models/GroupFileDownloadInfo.cs
+++ b/Mirai-CSharp.HttpApi/Models/GroupFileDownloadInfo.cs
@@ -1,4 +1,6 @@
+using System;
 using System.Text.Json.Serialization;
+using Mirai.CSharp.HttpApi.Utility.JsonConverters;
 using ISharedGroupFileDownloadInfo = Mirai.CSharp.Models.IGroupFileDownloadInfo;
 
 namespace Mirai.CSharp.HttpApi.Models
@@ -15,6 +17,17 @@ namespace Mirai.CSharp.HttpApi.Models
 
         [JsonPropertyName("url")]
         abstract string? ISharedGroupFileDownloadInfo.Url { get; }
+
+        [JsonPropertyName("downloadTimes")]
+        abstract int ISharedGroupFileDownloadInfo.DownloadedTimes { get; }
+
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("uploadTime")]
+        abstract DateTime ISharedGroupFileDownloadInfo.CreateTime { get; }
+
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("lastModifyTime")]
+        abstract DateTime ISharedGroupFileDownloadInfo.ModifyTime { get; }
 #else
         /// <inheritdoc cref="ISharedGroupFileDownloadInfo.Sha1"/>
         [JsonPropertyName("sha1")]
@@ -27,6 +40,20 @@ namespace Mirai.CSharp.HttpApi.Models
         /// <inheritdoc cref="ISharedGroupFileDownloadInfo.Url"/>
         [JsonPropertyName("url")]
         new string? Url { get; }
+        
+        /// <inheritdoc cref="ISharedGroupFileDownloadInfo.DownloadedTimes"/>
+        [JsonPropertyName("downloadTimes")]
+        new int DownloadedTimes { get; }
+        
+        /// <inheritdoc cref="ISharedGroupFileDownloadInfo.CreateTime"/>
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("uploadTime")]
+        new DateTime CreateTime { get; }
+        
+        /// <inheritdoc cref="ISharedGroupFileDownloadInfo.ModifyTime"/>
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("lastModifyTime")]
+        new DateTime ModifyTime { get; }
 #endif
     }
 
@@ -44,16 +71,33 @@ namespace Mirai.CSharp.HttpApi.Models
         [JsonPropertyName("url")]
         public string? Url { get; set; }
 
+        /// <inheritdoc/>
+        [JsonPropertyName("downloadTimes")]
+        public int DownloadedTimes { get; set; }
+
+        /// <inheritdoc/>
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("uploadTime")]
+        public DateTime CreateTime { get; set; }
+
+        /// <inheritdoc/>
+        [JsonConverter(typeof(UnixTimeStampJsonConverter))]
+        [JsonPropertyName("lastModifyTime")]
+        public DateTime ModifyTime { get; set; }
+
         public GroupFileDownloadInfo()
         {
 
         }
 
-        public GroupFileDownloadInfo(string sha1, string md5, string? url)
+        public GroupFileDownloadInfo(string sha1, string md5, string? url, int downloadedTimes, DateTime createTime, DateTime modifyTime)
         {
             Sha1 = sha1;
             Md5 = md5;
             Url = url;
+            DownloadedTimes = downloadedTimes;
+            CreateTime = createTime;
+            ModifyTime = modifyTime;
         }
     }
 }

--- a/Mirai-CSharp.HttpApi/Session/IMiraiHttpSession.MessageCache.cs
+++ b/Mirai-CSharp.HttpApi/Session/IMiraiHttpSession.MessageCache.cs
@@ -1,0 +1,20 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Mirai.CSharp.HttpApi.Models;
+using Mirai.CSharp.HttpApi.Parsers;
+
+namespace Mirai.CSharp.HttpApi.Session
+{
+    public partial interface IMiraiHttpSession
+    {
+        /// <summary>
+        /// 异步获取缓存于 mirai-api-http 的消息
+        /// </summary>
+        /// <exception cref="NotSupportedException"/>
+        /// <param name="messageId">消息Id</param>
+        /// <param name="token">用于取消此异步操作的 <see cref="CancellationToken"/></param>
+        /// <returns>表示此异步操作的 <see cref="Task"/></returns>
+        Task<IMiraiHttpMessage?> RetriveMessageAsync(int messageId, CancellationToken token = default);
+    }
+}

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Authentication.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Authentication.cs
@@ -130,7 +130,7 @@ namespace Mirai.CSharp.HttpApi.Session
             };
             using JsonDocument j = await client.PostAsJsonAsync<object>(url, payload, token).GetJsonAsync(token).ConfigureAwait(false);
             JsonElement root = j.RootElement;
-            root.EnsureApiRespCode(out _);
+            root.EnsureApiRespCode();
             return root.GetProperty("session").GetString()!;
         }
 
@@ -152,7 +152,7 @@ namespace Mirai.CSharp.HttpApi.Session
         {
             using JsonDocument j = await client.GetAsync($"{options.BaseUrl}/about", token).GetJsonAsync(token).ConfigureAwait(false);
             JsonElement root = j.RootElement;
-            root.EnsureApiRespCode(out _);
+            root.EnsureApiRespCode();
             string version = root.GetProperty("data").GetProperty("version").GetString()!;
             int vIndex = version.IndexOf('v');
 #if NETSTANDARD2_0

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Command.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Command.cs
@@ -39,7 +39,7 @@ namespace Mirai.CSharp.HttpApi.Session
             {
                 using JsonDocument j = JsonDocument.Parse(json);
                 JsonElement root = j.RootElement;
-                root.EnsureApiRespCode(out _);
+                root.EnsureApiRespCode();
             }
             catch (JsonException) // 返回值非json就是执行失败, 把响应正文重新抛出
             {
@@ -79,7 +79,7 @@ namespace Mirai.CSharp.HttpApi.Session
             {
                 using JsonDocument j = JsonDocument.Parse(json);
                 JsonElement root = j.RootElement;
-                root.EnsureApiRespCode(out _);
+                root.EnsureApiRespCode();
             }
             catch (JsonException) // 返回值非json就是执行失败, 把响应正文重新抛出
             {

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Command.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Command.cs
@@ -110,18 +110,26 @@ namespace Mirai.CSharp.HttpApi.Session
         /// <param name="client">要进行请求的 <see cref="HttpClient"/></param>
         /// <param name="options">连接信息</param>
         /// <inheritdoc cref="GetManagersAsync(long, CancellationToken)"/>
-        public static Task<long[]> GetManagersAsync(HttpClient client, MiraiHttpSessionOptions options, long qqNumber, CancellationToken token = default)
+        [Obsolete("新版本的 mirai-console 中已经没有管理员概念了, 参考: https://github.com/project-mirai/mirai-api-http/pull/265#discussion_r598428011")]
+        public static async Task<long[]> GetManagersAsync(HttpClient client, MiraiHttpSessionOptions options, long qqNumber, CancellationToken token = default)
         {
-            return client.GetAsync($"{options.BaseUrl}/managers?qq={qqNumber}", token).AsApiRespAsync<long[]>(token);
+            string json = await client.GetAsync($"{options.BaseUrl}/managers?qq={qqNumber}", token).GetStringAsync(token);
+            if (!string.IsNullOrEmpty(json))
+            {
+                return JsonSerializer.Deserialize<long[]>(json)!;
+            }
+            return Array.Empty<long>();
         }
 
         /// <inheritdoc cref="GetManagersAsync(HttpClient, MiraiHttpSessionOptions, long, CancellationToken)"/>
+        [Obsolete("新版本的 mirai-console 中已经没有管理员概念了, 参考: https://github.com/project-mirai/mirai-api-http/pull/265#discussion_r598428011")]
         public static Task<long[]> GetManagersAsync(MiraiHttpSessionOptions options, long qqNumber, CancellationToken token = default)
         {
             return GetManagersAsync(_globalClient, options, qqNumber, token);
         }
 
         /// <inheritdoc/>
+        [Obsolete("新版本的 mirai-console 中已经没有管理员概念了, 参考: https://github.com/project-mirai/mirai-api-http/pull/265#discussion_r598428011")]
         public override Task<long[]> GetManagersAsync(long qqNumber, CancellationToken token = default)
         {
             InternalSessionInfo session = SafeGetSession();

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Management.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Management.cs
@@ -24,7 +24,7 @@ namespace Mirai.CSharp.HttpApi.Session
             InternalSessionInfo session = SafeGetSession();
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
             return _client.GetAsync($"{_options.BaseUrl}/friendList?sessionKey={session.SessionKey}", token)
-                .AsApiRespAsync<ISharedFriendInfo[], FriendInfo[]>(token)
+                .AsApiRespV2Async<ISharedFriendInfo[], FriendInfo[]>(token)
                 .DisposeWhenCompleted(cts);
         }
 
@@ -34,7 +34,7 @@ namespace Mirai.CSharp.HttpApi.Session
             InternalSessionInfo session = SafeGetSession();
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
             return _client.GetAsync($"{_options.BaseUrl}/groupList?sessionKey={session.SessionKey}", token)
-                .AsApiRespAsync<ISharedGroupInfo[], GroupInfo[]>(token)
+                .AsApiRespV2Async<ISharedGroupInfo[], GroupInfo[]>(token)
                 .DisposeWhenCompleted(cts);
         }
 
@@ -44,7 +44,7 @@ namespace Mirai.CSharp.HttpApi.Session
             InternalSessionInfo session = SafeGetSession();
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
             return _client.GetAsync($"{_options.BaseUrl}/memberList?sessionKey={session.SessionKey}&target={groupNumber}", token)
-                .AsApiRespAsync<ISharedGroupMemberInfo[], GroupMemberInfo[]>(token)
+                .AsApiRespV2Async<ISharedGroupMemberInfo[], GroupMemberInfo[]>(token)
                 .DisposeWhenCompleted(cts);
         }
 
@@ -220,12 +220,12 @@ namespace Mirai.CSharp.HttpApi.Session
         }
 
         /// <inheritdoc/>
-        public override Task<ISharedGroupMemberCardInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber, CancellationToken token = default)
+        public override Task<ISharedGroupMemberInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber, CancellationToken token = default)
         {
             InternalSessionInfo session = SafeGetSession();
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
             return _client.GetAsync($"{_options.BaseUrl}/memberInfo?sessionKey={session.SessionKey}&target={groupNumber}&memberId={memberId}", token)
-                .AsApiRespAsync<ISharedGroupMemberCardInfo, GroupMemberCardInfo>(token)
+                .AsApiRespAsync<ISharedGroupMemberInfo, GroupMemberInfo>(token)
                 .DisposeWhenCompleted(cts);
         }
     }

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.MessageCache.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.MessageCache.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Mirai.CSharp.Extensions;
+using Mirai.CSharp.HttpApi.Extensions;
+using Mirai.CSharp.HttpApi.Models;
+using Mirai.CSharp.HttpApi.Parsers;
+
+namespace Mirai.CSharp.HttpApi.Session
+{
+    public partial class MiraiHttpSession
+    {
+        /// <inheritdoc/>
+        /// <remarks>
+        /// 当缓存失效, 或者未注册用于解析消息的 <see cref="IMiraiHttpMessageParser{TMessage}"/> 时, 本异步方法将返回 <see langword="null"/>
+        /// </remarks>
+        public async Task<IMiraiHttpMessage?> RetriveMessageAsync(int messageId, CancellationToken token = default)
+        {
+            InternalSessionInfo session = SafeGetSession();
+            IMiraiHttpMessageParserResolver resolver = _services.GetRequiredService<IMiraiHttpMessageParserResolver>();
+            CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
+            JsonElement root = await _client.GetAsync($"{_options.BaseUrl}/messageFromId?sessionKey={session.SessionKey}&id={messageId}", token)
+                .GetObjectAsync<JsonElement>(token)
+                .DisposeWhenCompleted(cts);
+            root.EnsureApiRespCode();
+            JsonElement data = root.GetProperty("data");
+            IMiraiHttpMessageParser? parser = resolver.ResolveParser(in data);
+            if (parser != null && parser.CanParse(in data))
+            {
+                return (IMiraiHttpMessage)parser.Parse(in data);
+            }
+            return null;
+        }
+    }
+}

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.SendImage.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.SendImage.cs
@@ -39,7 +39,7 @@ namespace Mirai.CSharp.HttpApi.Session
             };
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
             return _client.PostAsJsonAsync($"{_options.BaseUrl}/sendImageMessage", payload, JsonSerializeOptionsFactory.IgnoreNulls, token)
-                .AsApiRespAsync<string[]>(token)
+                .AsApiRespV2Async<string[]>(token)
                 .DisposeWhenCompleted(cts);
         }
         /// <inheritdoc/>

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.SendMessage.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.SendMessage.cs
@@ -63,7 +63,7 @@ namespace Mirai.CSharp.HttpApi.Session
             };
             using JsonDocument j = await _client.PostAsJsonAsync($"{_options.BaseUrl}/{action}", payload, _chatMessageSerializingOptions, token).GetJsonAsync(token).DisposeWhenCompleted(cts).ConfigureAwait(false);
             JsonElement root = j.RootElement;
-            root.EnsureApiRespCode(out _);
+            root.EnsureApiRespCode();
             return root.GetProperty("messageId").GetInt32();
         }
 

--- a/Mirai-CSharp.HttpApi/Utility/Utils.cs
+++ b/Mirai-CSharp.HttpApi/Utility/Utils.cs
@@ -1,7 +1,9 @@
 using System;
+#if !NET6_0_OR_GREATER
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Text.Json;
+#endif
 
 namespace Mirai.CSharp.HttpApi.Utility
 {

--- a/Mirai-CSharp/Framework/Builders/MessageFrameworkBuilder.cs
+++ b/Mirai-CSharp/Framework/Builders/MessageFrameworkBuilder.cs
@@ -231,15 +231,15 @@ namespace Mirai.CSharp.Framework.Builders
             }
         }
 
-        protected virtual void ReplaceServiceLifetime(HashSet<ServiceDescriptor> adddedDescriptors, ServiceLifetime lifetime)
+        protected virtual void ReplaceServiceLifetime(ICollection<ServiceDescriptor> addedDescriptors, ServiceLifetime lifetime)
         {
-            for (int i = Services.Count; i >= 0; i--)
+            for (int i = Services.Count - 1; i >= 0; i--)
             {
                 ServiceDescriptor descriptor = Services[i];
-                if (adddedDescriptors.Contains(descriptor) && descriptor.ImplementationInstance == null)
+                if (addedDescriptors.Contains(descriptor) && descriptor.ImplementationInstance == null)
                 {
                     Services.RemoveAt(i);
-                    adddedDescriptors.Remove(descriptor);
+                    addedDescriptors.Remove(descriptor);
                     if (descriptor.ImplementationFactory != null)
                     {
                         descriptor = new ServiceDescriptor(descriptor.ServiceType, descriptor.ImplementationFactory, lifetime);
@@ -249,7 +249,7 @@ namespace Mirai.CSharp.Framework.Builders
                         descriptor = new ServiceDescriptor(descriptor.ServiceType, descriptor.ImplementationType!, lifetime);
                     }
                     Services.Add(descriptor);
-                    adddedDescriptors.Add(descriptor);
+                    addedDescriptors.Add(descriptor);
                 }
             }
         }

--- a/Mirai-CSharp/Models/EventArgs/Bot/IBotJoinedGroupEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Bot/IBotJoinedGroupEventArgs.cs
@@ -3,7 +3,7 @@ namespace Mirai.CSharp.Models.EventArgs
     /// <summary>
     /// 提供Bot加入了一个新群相关信息的接口。继承自 <see cref="IGroupEventArgs"/>
     /// </summary>
-    public interface IBotJoinedGroupEventArgs : IGroupEventArgs
+    public interface IBotJoinedGroupEventArgs : IGroupEventArgs, IInviterEventArgs
     {
 
     }
@@ -11,7 +11,7 @@ namespace Mirai.CSharp.Models.EventArgs
     /// <summary>
     /// 提供Bot加入了一个新群相关信息的接口。继承自 <see cref="IBotJoinedGroupEventArgs"/> 和 <see cref="IGroupEventArgs{TRawdata}"/>
     /// </summary>
-    public interface IBotJoinedGroupEventArgs<TRawdata> : IBotJoinedGroupEventArgs, IGroupEventArgs<TRawdata>
+    public interface IBotJoinedGroupEventArgs<TRawdata> : IBotJoinedGroupEventArgs, IGroupEventArgs<TRawdata>, IInviterEventArgs<TRawdata>
     {
 
     }

--- a/Mirai-CSharp/Models/EventArgs/Bot/IBotKickedOutEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Bot/IBotKickedOutEventArgs.cs
@@ -1,17 +1,17 @@
 namespace Mirai.CSharp.Models.EventArgs
 {
     /// <summary>
-    /// 提供Bot被踢出一个群相关信息的接口。继承自 <see cref="IGroupEventArgs"/>
+    /// 提供Bot被踢出一个群相关信息的接口。继承自 <see cref="IGroupOperatingEventArgs"/>
     /// </summary>
-    public interface IBotKickedOutEventArgs : IGroupEventArgs
+    public interface IBotKickedOutEventArgs : IGroupOperatingEventArgs
     {
 
     }
 
     /// <summary>
-    /// 提供Bot被踢出一个群相关信息的接口。继承自 <see cref="IBotKickedOutEventArgs"/> 和 <see cref="IGroupEventArgs{TRawdata}"/>
+    /// 提供Bot被踢出一个群相关信息的接口。继承自 <see cref="IBotKickedOutEventArgs"/> 和 <see cref="IGroupOperatingEventArgs{TRawdata}"/>
     /// </summary>
-    public interface IBotKickedOutEventArgs<TRawdata> : IBotKickedOutEventArgs, IGroupEventArgs<TRawdata>
+    public interface IBotKickedOutEventArgs<TRawdata> : IBotKickedOutEventArgs, IGroupOperatingEventArgs<TRawdata>
     {
 
     }

--- a/Mirai-CSharp/Models/EventArgs/Group/IGroupEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/IGroupEventArgs.cs
@@ -82,4 +82,24 @@ namespace Mirai.CSharp.Models.EventArgs
     {
 
     }
+
+    /// <summary>
+    /// 提供邀请人相关信息的接口。
+    /// </summary>
+    public interface IInviterEventArgs : IMiraiMessage
+    {
+        /// <summary>
+        /// 邀请人信息
+        /// </summary>
+        /// <remarks>
+        /// 仅当 mirai-api-http 版本至少为 2.3.0 时, 此属性可能不为 <see langword="null"/>
+        /// </remarks>
+        IGroupMemberInfo? Inviter { get; }
+    }
+
+    /// <inheritdoc/>
+    public interface IInviterEventArgs<TRawdata> : IInviterEventArgs, IMiraiMessage<TRawdata>
+    {
+
+    }
 }

--- a/Mirai-CSharp/Models/EventArgs/Group/Specialized/IGroupMemberJoinedEventArgs.cs
+++ b/Mirai-CSharp/Models/EventArgs/Group/Specialized/IGroupMemberJoinedEventArgs.cs
@@ -3,7 +3,7 @@ namespace Mirai.CSharp.Models.EventArgs
     /// <summary>
     /// 提供新人入群相关信息的接口。继承自 <see cref="IMemberEventArgs"/>
     /// </summary>
-    public interface IGroupMemberJoinedEventArgs : IMemberEventArgs
+    public interface IGroupMemberJoinedEventArgs : IMemberEventArgs, IInviterEventArgs
     {
 
     }
@@ -11,7 +11,7 @@ namespace Mirai.CSharp.Models.EventArgs
     /// <summary>
     /// 提供新人入群相关信息的接口。继承自 <see cref="IGroupMemberJoinedEventArgs"/> 和 <see cref="IMemberEventArgs{TRawdata}"/>
     /// </summary>
-    public interface IGroupMemberJoinedEventArgs<TRawdata> : IGroupMemberJoinedEventArgs, IMemberEventArgs<TRawdata>
+    public interface IGroupMemberJoinedEventArgs<TRawdata> : IGroupMemberJoinedEventArgs, IMemberEventArgs<TRawdata>, IInviterEventArgs<TRawdata>
     {
 
     }

--- a/Mirai-CSharp/Models/IGroupFileDownloadInfo.cs
+++ b/Mirai-CSharp/Models/IGroupFileDownloadInfo.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Mirai.CSharp.Models
 {
     /// <summary>
@@ -19,5 +21,20 @@ namespace Mirai.CSharp.Models
         /// 对象下载链接
         /// </summary>
         string? Url { get; }
+
+        /// <summary>
+        /// 对象被下载次数
+        /// </summary>
+        int DownloadedTimes { get; }
+
+        /// <summary>
+        /// 对象创建时间
+        /// </summary>
+        DateTime CreateTime { get; }
+
+        /// <summary>
+        /// 对象修改时间
+        /// </summary>
+        DateTime ModifyTime { get; }
     }
 }

--- a/Mirai-CSharp/Session/IMiraiSession.Command.cs
+++ b/Mirai-CSharp/Session/IMiraiSession.Command.cs
@@ -37,6 +37,7 @@ namespace Mirai.CSharp.Session
         /// <param name="qqNumber">机器人QQ号</param>
         /// <param name="token">用于取消此异步操作的 <see cref="CancellationToken"/></param>
         /// <returns>表示此异步操作的 <see cref="Task"/>, 其值为能够管理此机器人的QQ号数组</returns>
+        [Obsolete("新版本的 mirai-console 中已经没有管理员概念了, 参考: https://github.com/project-mirai/mirai-api-http/pull/265#discussion_r598428011")]
         Task<long[]> GetManagersAsync(long qqNumber, CancellationToken token = default);
     }
 }

--- a/Mirai-CSharp/Session/IMiraiSession.Management.cs
+++ b/Mirai-CSharp/Session/IMiraiSession.Management.cs
@@ -154,7 +154,7 @@ namespace Mirai.CSharp.Session
         /// <param name="groupNumber">该用户所在群号</param>
         /// <param name="token">用于取消此异步操作的 <see cref="CancellationToken"/></param>
         /// <returns>表示此异步操作的 <see cref="Task"/></returns>
-        Task<IGroupMemberCardInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber, CancellationToken token = default);
+        Task<IGroupMemberInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber, CancellationToken token = default);
 
         /// <summary>
         /// 异步获取群成员列表

--- a/Mirai-CSharp/Session/MiraiSession.Command.cs
+++ b/Mirai-CSharp/Session/MiraiSession.Command.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -18,6 +19,7 @@ namespace Mirai.CSharp.Session
         public abstract Task RegisterCommandAsync(string name, string[]? alias = null, string? description = null, string? usage = null, CancellationToken token = default);
 
         /// <inheritdoc/>
+        [Obsolete("新版本的 mirai-console 中已经没有管理员概念了, 参考: https://github.com/project-mirai/mirai-api-http/pull/265#discussion_r598428011")]
         public abstract Task<long[]> GetManagersAsync(long qqNumber, CancellationToken token = default);
     }
 }

--- a/Mirai-CSharp/Session/MiraiSession.Management.cs
+++ b/Mirai-CSharp/Session/MiraiSession.Management.cs
@@ -47,7 +47,7 @@ namespace Mirai.CSharp.Session
         public abstract Task ChangeGroupMemberInfoAsync(long memberId, long groupNumber, IGroupMemberCardInfo info, CancellationToken token = default);
 
         /// <inheritdoc/>
-        public abstract Task<IGroupMemberCardInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber, CancellationToken token = default);
+        public abstract Task<IGroupMemberInfo> GetGroupMemberInfoAsync(long memberId, long groupNumber, CancellationToken token = default);
 
         /// <inheritdoc/>
         public abstract Task<IGroupMemberInfo[]> GetGroupMemberListAsync(long groupNumber, CancellationToken token = default);


### PR DESCRIPTION
close #72 
close #75 
close #77 
close #39 
close #73 

- 修复了替换服务时错误遍历已注册服务的问题
- 更改 `MessageFrameworkBuilder<TInvokerService, TClientService, THandlerService>.ReplaceServiceLifetime` 第一个参数类型到 `ICollection<ServiceDescriptor>`, 并修复了参数名 typo 的问题
- 为 `UnknownResponseException` 新增了两个构造函数
- 条件编译 `Mirai.CSharp.HttpApi.Utility.Utils.Deserialize<T>(JsonElement, JsonSerializerOptions? options)` 及其附带字段
- 新增 `IInviterEventArgs` 接口, 其提供受邀入群时邀请人的相关信息
- `IBotKickedOutEventArgs` 现在继承自 `IGroupOperatingEventArgs`
- 解决 HttpApi 中的 `IOperatorEventArgs` 在实现基接口中的 `Operator` 时, 错误给定 `ChangeTypeJsonConverter` 的类型参数的问题
- 修复 `FriendEventArgs.Friend` 属性的特性内错误给定 `ChangeTypeJsonConverter` 类型参数的问题
- 修复 `BotReloginEventArgs` 类实现错误接口的问题
- 移除 `EnsureApiRespCode` 签名中的 out 参数
- 添加从缓存中获取消息的方法
- 为 `IGroupFileDownloadInfo` 添加了更多属性
- 弃用 `IMiraiSession.GetManagersAsync`
- 更改 `IMiraiSession.GetGroupMemberInfoAsync` 返回类型为 `Task<IGroupMemberInfo>`
- 修复 `IMiraiHttpSession.GetFilelistAsync` 和 `GetFileInfoAsync` 无法使用的问题
- 修复 `IMiraiHttpSession.SendImageTo(Friend/Temp/Group)Async` 无法使用的问题