### PR TITLE
更新至v2.1.2

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <NoWin32Manifest>true</NoWin32Manifest>
-        <Version>2.1.1.0</Version>
-        <AssemblyVersion>2.1.1.0</AssemblyVersion>
-        <FileVersion>2.1.1.0</FileVersion>
-        <PackageVersion>2.1.1.0</PackageVersion>
+        <Version>2.1.2.0</Version>
+        <AssemblyVersion>2.1.2.0</AssemblyVersion>
+        <FileVersion>2.1.2.0</FileVersion>
+        <PackageVersion>2.1.2.0</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.HttpApi/Models/GroupConfig.cs
+++ b/Mirai-CSharp.HttpApi/Models/GroupConfig.cs
@@ -10,10 +10,10 @@ namespace Mirai.CSharp.HttpApi.Models
 #if NETSTANDARD2_0
         /// <inheritdoc cref="ISharedGroupConfig.Name"/>
         [JsonPropertyName("name")]
-        new string Name { get; }
+        new string? Name { get; }
         /// <inheritdoc cref="ISharedGroupConfig.Announcement"/>
         [JsonPropertyName("announcement")]
-        new string Announcement { get; }
+        new string? Announcement { get; }
         /// <inheritdoc cref="ISharedGroupConfig.ConfessTalk"/>
         [JsonPropertyName("confessTalk")]
         new bool? ConfessTalk { get; }
@@ -29,10 +29,10 @@ namespace Mirai.CSharp.HttpApi.Models
 #else
         /// <inheritdoc/>
         [JsonPropertyName("name")]
-        abstract string ISharedGroupConfig.Name { get; }
+        abstract string? ISharedGroupConfig.Name { get; }
         /// <inheritdoc/>
         [JsonPropertyName("announcement")]
-        abstract string ISharedGroupConfig.Announcement { get; }
+        abstract string? ISharedGroupConfig.Announcement { get; }
         /// <inheritdoc/>
         [JsonPropertyName("confessTalk")]
         abstract bool? ISharedGroupConfig.ConfessTalk { get; }
@@ -52,10 +52,10 @@ namespace Mirai.CSharp.HttpApi.Models
     {
         /// <inheritdoc/>
         [JsonPropertyName("name")]
-        public string Name { get; set; } = null!;
+        public string? Name { get; set; }
         /// <inheritdoc/>
         [JsonPropertyName("announcement")]
-        public string Announcement { get; set; } = null!;
+        public string? Announcement { get; set; }
         /// <inheritdoc/>
         [JsonPropertyName("confessTalk")]
         public bool? ConfessTalk { get; set; }
@@ -75,7 +75,7 @@ namespace Mirai.CSharp.HttpApi.Models
 
         }
 
-        public GroupConfig(string name, string announcement, bool? confessTalk, bool? memberInvite, bool? autoApprove, bool? anonymousChat)
+        public GroupConfig(string? name, string? announcement, bool? confessTalk, bool? memberInvite, bool? autoApprove, bool? anonymousChat)
         {
             Name = name;
             Announcement = announcement;
@@ -87,10 +87,10 @@ namespace Mirai.CSharp.HttpApi.Models
 
 #if NETSTANDARD2_0
         [JsonPropertyName("name")]
-        string ISharedGroupConfig.Name => Name;
+        string? ISharedGroupConfig.Name => Name;
 
         [JsonPropertyName("announcement")]
-        string ISharedGroupConfig.Announcement => Announcement;
+        string? ISharedGroupConfig.Announcement => Announcement;
 
         [JsonPropertyName("confessTalk")]
         bool? ISharedGroupConfig.ConfessTalk => ConfessTalk;

--- a/Mirai-CSharp.HttpApi/Models/GroupMemberCardInfo.cs
+++ b/Mirai-CSharp.HttpApi/Models/GroupMemberCardInfo.cs
@@ -10,17 +10,17 @@ namespace Mirai.CSharp.HttpApi.Models
 #if NETSTANDARD2_0
         /// <inheritdoc cref="ISharedGroupMemberCardInfo.Name"/>
         [JsonPropertyName("name")]
-        new string Name { get; }
+        new string? Name { get; }
         /// <inheritdoc cref="ISharedGroupMemberCardInfo.SpecialTitle"/>
         [JsonPropertyName("specialTitle")]
-        new string SpecialTitle { get; }
+        new string? SpecialTitle { get; }
 #else
         /// <inheritdoc/>
         [JsonPropertyName("name")]
-        abstract string ISharedGroupMemberCardInfo.Name { get; }
+        abstract string? ISharedGroupMemberCardInfo.Name { get; }
         /// <inheritdoc/>
         [JsonPropertyName("specialTitle")]
-        abstract string ISharedGroupMemberCardInfo.SpecialTitle { get; }
+        abstract string? ISharedGroupMemberCardInfo.SpecialTitle { get; }
 #endif
     }
 
@@ -30,12 +30,12 @@ namespace Mirai.CSharp.HttpApi.Models
         /// 群名片
         /// </summary>
         [JsonPropertyName("name")]
-        public string Name { get; set; } = null!;
+        public string? Name { get; set; }
         /// <summary>
         /// 专属头衔
         /// </summary>
         [JsonPropertyName("specialTitle")]
-        public string SpecialTitle { get; set; } = null!;
+        public string? SpecialTitle { get; set; }
 
         [Obsolete("此类不应由用户主动创建实例。")]
         public GroupMemberCardInfo()
@@ -43,18 +43,18 @@ namespace Mirai.CSharp.HttpApi.Models
 
         }
 
-        [Obsolete("此类不应由用户主动创建实例。")]
-        public GroupMemberCardInfo(string name, string specialTitle)
+        public GroupMemberCardInfo(string? name, string? specialTitle)
         {
-            
+            Name = name;
+            SpecialTitle = specialTitle;
         }
 
 #if NETSTANDARD2_0
         [JsonPropertyName("name")]
-        string ISharedGroupMemberCardInfo.Name => Name;
+        string? ISharedGroupMemberCardInfo.Name => Name;
 
         [JsonPropertyName("specialTitle")]
-        string ISharedGroupMemberCardInfo.SpecialTitle => SpecialTitle;
+        string? ISharedGroupMemberCardInfo.SpecialTitle => SpecialTitle;
 #endif
     }
 }

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Management.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Management.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using Mirai.CSharp.Extensions;
@@ -185,7 +186,7 @@ namespace Mirai.CSharp.HttpApi.Session
             {
                 sessionKey = session.SessionKey,
                 target = groupNumber,
-                config
+                config = (object)config
             };
             return _client.PostAsJsonAsync($"{_options.BaseUrl}/groupConfig", payload, JsonSerializeOptionsFactory.IgnoreNulls, token)
                 .AsApiRespAsync(token)
@@ -212,9 +213,9 @@ namespace Mirai.CSharp.HttpApi.Session
                 sessionKey = session.SessionKey,
                 target = groupNumber,
                 memberId,
-                info
+                info = (object)info
             };
-            return _client.PostAsJsonAsync($"{_options.BaseUrl}/memberInfo", payload, token)
+            return _client.PostAsJsonAsync($"{_options.BaseUrl}/memberInfo", payload, JsonSerializeOptionsFactory.IgnoreNulls, token)
                 .AsApiRespAsync(token)
                 .DisposeWhenCompleted(cts);
         }

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.cs
@@ -135,14 +135,13 @@ namespace Mirai.CSharp.HttpApi.Session
         public PluginResistration AddPlugin(IMiraiHttpMessageHandler plugin)
         {
             CheckDisposed();
-            PluginResistration registration = default;
             LinkedList<DynamicHandlerRegistration> registrations = new LinkedList<DynamicHandlerRegistration>();
             IMiraiHttpMessageSubscriptionResolver resolver = _services.GetRequiredService<IMiraiHttpMessageSubscriptionResolver>();
             foreach (IMiraiHttpMessageSubscription? subscription in resolver.ResolveByHandler(plugin.GetType()))
             {
                 registrations.AddLast(subscription.AddHandler(plugin));
             }
-            return registration;
+            return new PluginResistration(registrations);
         }
 
         /// <inheritdoc/>

--- a/Mirai-CSharp.HttpApi/Session/PluginResistration.cs
+++ b/Mirai-CSharp.HttpApi/Session/PluginResistration.cs
@@ -8,6 +8,11 @@ namespace Mirai.CSharp.HttpApi.Session
     {
         internal LinkedList<DynamicHandlerRegistration>? _registrations;
 
+        public PluginResistration(LinkedList<DynamicHandlerRegistration> registrations)
+        {
+            _registrations = registrations;
+        }
+
         public void Dispose()
         {
             if (_registrations is LinkedList<DynamicHandlerRegistration> registrations)

--- a/Mirai-CSharp/Models/IGroupConfig.cs
+++ b/Mirai-CSharp/Models/IGroupConfig.cs
@@ -8,11 +8,11 @@ namespace Mirai.CSharp.Models
         /// <summary>
         /// 群名
         /// </summary>
-        string Name { get; }
+        string? Name { get; }
         /// <summary>
         /// 群公告
         /// </summary>
-        string Announcement { get; }
+        string? Announcement { get; }
         /// <summary>
         /// 是否允许坦白说
         /// </summary>

--- a/Mirai-CSharp/Models/IGroupMemberCardInfo.cs
+++ b/Mirai-CSharp/Models/IGroupMemberCardInfo.cs
@@ -8,10 +8,10 @@ namespace Mirai.CSharp.Models
         /// <summary>
         /// 群名片
         /// </summary>
-        string Name { get; }
+        string? Name { get; }
         /// <summary>
         /// 专属头衔
         /// </summary>
-        string SpecialTitle { get; }
+        string? SpecialTitle { get; }
     }
 }


### PR DESCRIPTION
- 更改 `(I)GroupConfig.Name` 和 `(I)GroupConfig.Announcement` 的返回值为 `string?`
- 更改 `(I)GroupMemberCardInfo.Name` 和 `(I)GroupMemberCardInfo.SpecialTitle` 的返回值为 `string?`
- 取消 `GroupMemberCardInfo(string?, string?)` 的弃用特性
- 修复无法正常使用 `ChangeGroupConfigAsync`, `ChangeGroupMemberInfoAsync` 接口的问题

> 注: 在现行的所有 `System.Text.Json` 版本下, 因无法序列化非公共属性/字段, 导致在 `Mirai-CSharp.HttpApi` 下的模型接口中重新抽象的属性无法被正确序列化(它们都是非公共属性, 具体请用反射自行查看), 暂时令发送请求时的 payload 中的这些模型接口为 `object` 类型以令 `System.Text.Json` 正确序列化请求负载。
> 注2: 以上问题对 `NETStandard 2.0` 不适用, 因为其下的运行时不支持接口成员重新抽象, 所以本项目使用 `new` 关键字覆盖基接口成员。
> 注3: 继注2, 若以后 `System.Text.Json` 支持序列化接口类型时序列化其所有基接口成员, 可能会导致基接口被覆盖的成员和子接口成员冲突, 考虑添加 `JsonIgnoreAttribute` 以禁用基接口被覆盖的成员被序列化。