### PR TITLE
更新至v2.1.3

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <NoWin32Manifest>true</NoWin32Manifest>
-        <Version>2.1.2.0</Version>
-        <AssemblyVersion>2.1.2.0</AssemblyVersion>
-        <FileVersion>2.1.2.0</FileVersion>
-        <PackageVersion>2.1.2.0</PackageVersion>
+        <Version>2.1.3.0</Version>
+        <AssemblyVersion>2.1.3.0</AssemblyVersion>
+        <FileVersion>2.1.3.0</FileVersion>
+        <PackageVersion>2.1.3.0</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Validation.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.Validation.cs
@@ -5,7 +5,7 @@ namespace Mirai.CSharp.HttpApi.Session
 {
     public partial class MiraiHttpSession
     {
-        private void CheckDisposed()
+        protected void CheckDisposed()
         {
             if (Volatile.Read(ref _instanceCts) == null)
             {
@@ -13,11 +13,15 @@ namespace Mirai.CSharp.HttpApi.Session
             }
         }
 
-        private InternalSessionInfo SafeGetSession()
+        protected InternalSessionInfo SafeGetSession()
         {
             CheckDisposed();
             InternalSessionInfo? session = _currentSession;
-            return session ?? throw new InvalidOperationException("请先连接到一个Session。");
+            if (session == null || !session.Connected)
+            {
+                throw new InvalidOperationException("请先连接到一个Session。");
+            }
+            return session;
         }
     }
 }

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.cs
@@ -101,7 +101,7 @@ namespace Mirai.CSharp.HttpApi.Session
             _client = client;
             _invoker = invoker;
             _coder = coder;
-            JsonSerializerOptions chatMessageSerializingOptions = new JsonSerializerOptions();
+            JsonSerializerOptions chatMessageSerializingOptions = JsonSerializeOptionsFactory.IgnoreNulls;
             chatMessageSerializingOptions.Converters.Add(jsonConverter);
             _chatMessageSerializingOptions = chatMessageSerializingOptions;
             _instanceCts = new CancellationTokenSource();


### PR DESCRIPTION
close #110 
- `SafeGetSession` 方法应判断 session 是否已经连接成功
- 更改 `SafeGetSession` 和 `CheckDisposed` 方法的访问权限为 protected
- 修复因错误序列化具有 null 值的字段导致 `AtMessage` 无法正确发送的问题