### PR TITLE
更新至v2.1.4

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <NoWin32Manifest>true</NoWin32Manifest>
-        <Version>2.1.3.0</Version>
-        <AssemblyVersion>2.1.3.0</AssemblyVersion>
-        <FileVersion>2.1.3.0</FileVersion>
-        <PackageVersion>2.1.3.0</PackageVersion>
+        <Version>2.1.4.0</Version>
+        <AssemblyVersion>2.1.4.0</AssemblyVersion>
+        <FileVersion>2.1.4.0</FileVersion>
+        <PackageVersion>2.1.4.0</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.HttpApi/Extensions/ApiResponseExtensions.cs
+++ b/Mirai-CSharp.HttpApi/Extensions/ApiResponseExtensions.cs
@@ -33,7 +33,7 @@ namespace Mirai.CSharp.HttpApi.Extensions
         /// <item><term><see cref="UnknownResponseException"/></term><description>其它情况</description></item>
         /// </list>
         /// </returns>
-        internal static Exception GetCommonException(int code, in JsonElement root)
+        public static Exception GetCommonException(int code, in JsonElement root)
         {
             return code switch
             {
@@ -116,7 +116,7 @@ namespace Mirai.CSharp.HttpApi.Extensions
             var root = j.RootElement;
             if (root.CheckApiRespCode(out var code))
             {
-                if (root.TryGetProperty("data", out JsonElement data))
+                if (root.ValueKind == JsonValueKind.Object && root.TryGetProperty("data", out JsonElement data))
                 {
                     return data.Deserialize<TImpl>()!;
                 }

--- a/Mirai-CSharp.HttpApi/Options/MiraiHttpSessionOptions.cs
+++ b/Mirai-CSharp.HttpApi/Options/MiraiHttpSessionOptions.cs
@@ -1,3 +1,5 @@
+using Mirai.CSharp.HttpApi.Invoking;
+
 namespace Mirai.CSharp.HttpApi.Options
 {
     public class MiraiHttpSessionOptions
@@ -14,6 +16,13 @@ namespace Mirai.CSharp.HttpApi.Options
         /// 配置mirai-api-http时的AuthKey
         /// </summary>
         public string AuthKey { get; set; } = null!;
+        /// <summary>
+        /// 指示不要异步等待消息被 <see cref="IMiraiHttpMessageHandlerInvoker"/> 处理完毕
+        /// </summary>
+        /// <remarks>
+        /// 若此属性值为 <see langword="true"/>, 将不保证消息进入相应处理器的先后顺序
+        /// </remarks>
+        public bool SuppressAwaitMessageInvoker { get; set; }
         /// <summary>
         /// 内部使用。
         /// </summary>

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.ReceiveMessage.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.ReceiveMessage.cs
@@ -58,7 +58,11 @@ namespace Mirai.CSharp.HttpApi.Session
                     }
                     try
                     {
-                        await _invoker.HandleRawdataAsync(this, root).ConfigureAwait(false);
+                        Task handleTask = _invoker.HandleRawdataAsync(this, root);
+                        if (!_options.SuppressAwaitMessageInvoker)
+                        {
+                            await handleTask.ConfigureAwait(false);
+                        }
                     }
                     catch (Exception)
                     {


### PR DESCRIPTION
close #114 
close #116 

- 允许通过设置 `MiraiHttpSessionOptions.SuppressAwaitMessageInvoker` 以禁止异步等待消息处理完成
- 解决在Linux下无法使用 `Mirai.CSharp.HttpApi.Utility.Utils.Deserialize<T>(this JsonElement, JsonSerializerOptions?)` 方法的问题
- 修复了不能反序列化 `mirai-api-http` 1.X 部分响应的问题