### PR TITLE
添加对userProfile接口的支持

### DIFF
--- a/Mirai-CSharp.HttpApi/Models/UserProfile.cs
+++ b/Mirai-CSharp.HttpApi/Models/UserProfile.cs
@@ -1,0 +1,26 @@
+using System;
+using ISharedUserProfile = Mirai.CSharp.Models.IUserProfile;
+
+namespace Mirai.CSharp.HttpApi.Models
+{
+    /// <inheritdoc cref="ISharedFriendProfile"/>
+    public interface IUserProfile : ISharedUserProfile, ICommonProfile
+    {
+
+    }
+
+    public class UserProfile : CommonProfile, IUserProfile
+    {
+        [Obsolete("此类不应由用户主动创建实例。")]
+        public UserProfile()
+        {
+
+        }
+
+        [Obsolete("此类不应由用户主动创建实例。")]
+        public UserProfile(string nickname, string email, int age, int level, string sign, CSharp.Models.ProfileGender gender) : base(nickname, email, age, level, sign, gender)
+        {
+            
+        }
+    }
+}

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.FetchProfile.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.FetchProfile.cs
@@ -37,6 +37,10 @@ namespace Mirai.CSharp.HttpApi.Session
         {
             InternalSessionInfo session = SafeGetSession();
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
+            if (session.ApiVersion < new System.Version(2, 4))
+            {
+                throw new System.NotSupportedException("本接口仅在 mirai-api-http v2.4.0 及以上版本提供");
+            }
             return _client.GetAsync($"{_options.BaseUrl}/userProfile?sessionKey={session.SessionKey}&userId={qqNumber}", token)
                 .AsApiRespAsync<ISharedUserProfile, UserProfile>(token)
                 .DisposeWhenCompleted(cts);

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.FetchProfile.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.FetchProfile.cs
@@ -4,6 +4,7 @@ using Mirai.CSharp.Extensions;
 using Mirai.CSharp.HttpApi.Extensions;
 using Mirai.CSharp.HttpApi.Models;
 using ISharedBotProfile = Mirai.CSharp.Models.IBotProfile;
+using ISharedUserProfile = Mirai.CSharp.Models.IUserProfile;
 using ISharedFriendProfile = Mirai.CSharp.Models.IFriendProfile;
 using ISharedGroupMemberProfile = Mirai.CSharp.Models.IGroupMemberProfile;
 
@@ -28,6 +29,16 @@ namespace Mirai.CSharp.HttpApi.Session
             CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
             return _client.GetAsync($"{_options.BaseUrl}/friendProfile?sessionKey={session.SessionKey}&target={qqNumber}", token)
                 .AsApiRespAsync<ISharedFriendProfile, FriendProfile>(token)
+                .DisposeWhenCompleted(cts);
+        }
+
+        /// <inheritdoc/>
+        public override Task<ISharedUserProfile> GetUserProfileAsync(long qqNumber, CancellationToken token = default)
+        {
+            InternalSessionInfo session = SafeGetSession();
+            CreateLinkedUserSessionToken(session.Token, token, out CancellationTokenSource? cts, out token);
+            return _client.GetAsync($"{_options.BaseUrl}/userProfile?sessionKey={session.SessionKey}&userId={qqNumber}", token)
+                .AsApiRespAsync<ISharedUserProfile, UserProfile>(token)
                 .DisposeWhenCompleted(cts);
         }
 

--- a/Mirai-CSharp/Models/IUserProfile.cs
+++ b/Mirai-CSharp/Models/IUserProfile.cs
@@ -1,0 +1,10 @@
+namespace Mirai.CSharp.Models
+{
+    /// <summary>
+    /// 提供任意QQ资料信息的接口
+    /// </summary>
+    public interface IUserProfile : ICommonProfile
+    {
+
+    }
+}

--- a/Mirai-CSharp/Session/IMiraiSession.FetchProfile.cs
+++ b/Mirai-CSharp/Session/IMiraiSession.FetchProfile.cs
@@ -22,6 +22,14 @@ namespace Mirai.CSharp.Session
         Task<IFriendProfile> GetFriendProfileAsync(long qqNumber, CancellationToken token = default);
 
         /// <summary>
+        /// 异步获取给定QQ的资料
+        /// </summary>
+        /// <param name="qqNumber">QQ号</param>
+        /// <param name="token">用于取消此异步操作的 <see cref="CancellationToken"/></param>
+        /// <returns>给定QQ的资料</returns>
+        Task<IUserProfile> GetUserProfileAsync(long qqNumber, CancellationToken token = default);
+
+        /// <summary>
         /// 异步获取给定群员的资料
         /// </summary>
         /// <param name="groupMember">群员所在群号</param>

--- a/Mirai-CSharp/Session/IMiraiSession.FetchProfile.cs
+++ b/Mirai-CSharp/Session/IMiraiSession.FetchProfile.cs
@@ -26,6 +26,9 @@ namespace Mirai.CSharp.Session
         /// </summary>
         /// <param name="qqNumber">QQ号</param>
         /// <param name="token">用于取消此异步操作的 <see cref="CancellationToken"/></param>
+        /// <remarks>
+        /// 需要mirai-api-http版本大于2.4.0
+        /// </remarks>
         /// <returns>给定QQ的资料</returns>
         Task<IUserProfile> GetUserProfileAsync(long qqNumber, CancellationToken token = default);
 

--- a/Mirai-CSharp/Session/MiraiSession.FetchProfile.cs
+++ b/Mirai-CSharp/Session/MiraiSession.FetchProfile.cs
@@ -14,5 +14,8 @@ namespace Mirai.CSharp.Session
 
         /// <inheritdoc/>
         public abstract Task<IGroupMemberProfile> GetGroupMemberProfileAsync(long groupMember, long qqNumber, CancellationToken token = default);
+
+        /// <inheritdoc/>
+        public abstract Task<IUserProfile> GetUserProfileAsync(long qqNumber, CancellationToken token = default);
     }
 }


### PR DESCRIPTION
fix #28
添加对userProfile接口的支持

经测试，添加的接口可以获取任意QQ号的资料卡信息，可以满足#28的需要。
本PullRequest依赖 https://github.com/project-mirai/mirai-api-http/pull/539 ，需要在该Pr结束后被合并。