### PR TITLE
更新至v2.1.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <NoWin32Manifest>true</NoWin32Manifest>
-        <Version>2.1.5.0</Version>
-        <AssemblyVersion>2.1.5.0</AssemblyVersion>
-        <FileVersion>2.1.5.0</FileVersion>
-        <PackageVersion>2.1.5.0</PackageVersion>
+        <Version>2.1.6.0</Version>
+        <AssemblyVersion>2.1.6.0</AssemblyVersion>
+        <FileVersion>2.1.6.0</FileVersion>
+        <PackageVersion>2.1.6.0</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.Example.Hosting/Controllers/RobotController.Add.cs
+++ b/Mirai-CSharp.Example.Hosting/Controllers/RobotController.Add.cs
@@ -1,0 +1,19 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mirai.CSharp.Example.Hosting.Controllers
+{
+    public sealed partial class RobotController
+    {
+        [HttpGet]
+        [HttpPost]
+        [Route("[action]")]
+        public async Task<IActionResult> AddAsync([Required]int robotQQ, CancellationToken token)
+        {
+            await _robotManager.RetriveSessionAsync(robotQQ, token);
+            return (JsonResult)ResponseModel.CreateSuccess();
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Controllers/RobotController.AddFriendMessageHandler.cs
+++ b/Mirai-CSharp.Example.Hosting/Controllers/RobotController.AddFriendMessageHandler.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Mirai.CSharp.Example.Hosting.Handlers;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting.Controllers
+{
+    public sealed partial class RobotController
+    {
+        [HttpGet]
+        [HttpPost]
+        [Route("[action]")]
+        public async Task<IActionResult> AddFriendMessageHandlerAsync([Required] int robotQQ, CancellationToken token)
+        {
+            IMiraiHttpSession session = await _robotManager.RetriveSessionAsync(robotQQ, token);
+            session.AddPlugin(new FriendMessageHandler());
+            return (JsonResult)ResponseModel.CreateSuccess();
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Controllers/RobotController.AddGroupMessageHandler.cs
+++ b/Mirai-CSharp.Example.Hosting/Controllers/RobotController.AddGroupMessageHandler.cs
@@ -1,0 +1,22 @@
+using System.ComponentModel.DataAnnotations;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Mirai.CSharp.Example.Hosting.Handlers;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting.Controllers
+{
+    public sealed partial class RobotController
+    {
+        [HttpGet]
+        [HttpPost]
+        [Route("[action]")]
+        public async Task<IActionResult> AddGroupMessageHandlerAsync([Required] int robotQQ, CancellationToken token)
+        {
+            IMiraiHttpSession session = await _robotManager.RetriveSessionAsync(robotQQ, token);
+            session.AddPlugin(new GroupMessageHandler());
+            return (JsonResult)ResponseModel.CreateSuccess();
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Controllers/RobotController.cs
+++ b/Mirai-CSharp.Example.Hosting/Controllers/RobotController.cs
@@ -1,0 +1,17 @@
+using Microsoft.AspNetCore.Mvc;
+using Mirai.CSharp.Example.Hosting.Services;
+
+namespace Mirai.CSharp.Example.Hosting.Controllers
+{
+    [ApiController]
+    [Route("[controller]")]
+    public sealed partial class RobotController : ControllerBase
+    {
+        private readonly RobotManager _robotManager;
+
+        public RobotController(RobotManager robotManager)
+        {
+            _robotManager = robotManager;
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Handlers/AutoRejectFriendApplyHandler.cs
+++ b/Mirai-CSharp.Example.Hosting/Handlers/AutoRejectFriendApplyHandler.cs
@@ -1,0 +1,30 @@
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Mirai.CSharp.HttpApi.Handlers;
+using Mirai.CSharp.HttpApi.Models.EventArgs;
+using Mirai.CSharp.HttpApi.Parsers;
+using Mirai.CSharp.HttpApi.Parsers.Attributes;
+using Mirai.CSharp.HttpApi.Session;
+using Mirai.CSharp.Models;
+
+namespace Mirai.CSharp.Example.Hosting.Handlers
+{
+    [RegisterMiraiHttpParser(typeof(DefaultMappableMiraiHttpMessageParser<INewFriendApplyEventArgs, NewFriendApplyEventArgs>))]
+    public partial class AutoRejectFriendApplyHandler : IMiraiHttpMessageHandler<INewFriendApplyEventArgs>
+    {
+        private readonly ILogger<AutoRejectFriendApplyHandler> _logger;
+
+        public AutoRejectFriendApplyHandler(ILogger<AutoRejectFriendApplyHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        public Task HandleMessageAsync(IMiraiHttpSession session, INewFriendApplyEventArgs e)
+        {
+            _logger.LogWarning($"已自动拒绝加好友请求。来源:{e.FromQQ}");
+            return session.HandleNewFriendApplyAsync(e, FriendApplyAction.Deny, "略略略");
+            // 把整个事件信息直接作为第一个参数即可, 然后根据自己需要选择一个 FriendApplyAction 枚举去处理请求
+            // 你也可以暂存 INewFriendApplyEventArgs e, 之后再调用 session 处理
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Handlers/DefaultDisconnectedHandler.cs
+++ b/Mirai-CSharp.Example.Hosting/Handlers/DefaultDisconnectedHandler.cs
@@ -1,0 +1,43 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Mirai.CSharp.HttpApi.Handlers;
+using Mirai.CSharp.HttpApi.Models.EventArgs;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting.Handlers
+{
+    public sealed class DefaultDisconnectedHandler : IMiraiHttpMessageHandler<IDisconnectedEventArgs>
+    {
+        private readonly ILogger<DefaultDisconnectedHandler> _logger;
+
+        public DefaultDisconnectedHandler(ILogger<DefaultDisconnectedHandler> logger)
+        {
+            _logger = logger;
+        }
+
+        public async Task HandleMessageAsync(IMiraiHttpSession session, IDisconnectedEventArgs message)
+        {
+            _logger.LogWarning(message.Exception, $"连接被断开。上一次连接的QQ号为:{message.LastConnectedQQNumber}");
+            while (!session.Connected) // 防止以前的handler未能正确阻断消息传递
+            {
+                try
+                {
+                    await session.ConnectAsync(message.LastConnectedQQNumber);
+                    message.BlockRemainingHandlers = true;
+                    _logger.LogInformation($"重连成功");
+                    break;
+                }
+                catch (ObjectDisposedException)
+                {
+                    break;
+                }
+                catch (Exception e)
+                {
+                    _logger.LogError(e, $"重连失败。上一次连接的QQ号为:{message.LastConnectedQQNumber}");
+                    await Task.Delay(1000);
+                }
+            }
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Handlers/FriendMessageHandler.cs
+++ b/Mirai-CSharp.Example.Hosting/Handlers/FriendMessageHandler.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mirai.CSharp.Builders;
+using Mirai.CSharp.HttpApi.Handlers;
+using Mirai.CSharp.HttpApi.Models.ChatMessages;
+using Mirai.CSharp.HttpApi.Models.EventArgs;
+using Mirai.CSharp.HttpApi.Parsers;
+using Mirai.CSharp.HttpApi.Parsers.Attributes;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting.Handlers
+{
+    [RegisterMiraiHttpParser(typeof(DefaultMappableMiraiHttpMessageParser<IFriendMessageEventArgs, FriendMessageEventArgs>))]
+    public partial class FriendMessageHandler : IMiraiHttpMessageHandler<IFriendMessageEventArgs>
+    {
+        public async Task HandleMessageAsync(IMiraiHttpSession session, IFriendMessageEventArgs e) // 法3: 使用 params IMessageBase[]
+        {
+            IMessageChainBuilder builder = session.GetMessageChainBuilder();
+            builder.AddPlainMessage($"收到了来自{e.Sender.Name}({e.Sender.Remark})[{e.Sender.Id}]的私聊消息:{string.Join(null, (IEnumerable<IChatMessage>)e.Chain)}");
+            //                                 /   好友昵称  /  /    好友备注    /  /  好友QQ号  /                                                        / 消息链 /
+            // builder.AddPlainMessage("QAQ").AddPlainMessage("TvT")/* .AddAtMessage(123456) etc... */;
+            // 你甚至可以一开始 new MessageBuilder() 的时候就开始 Chaining
+            await session.SendFriendMessageAsync(e.Sender.Id, builder); // 向消息来源群异步发送由以上chain表示的消息
+            // e.BlockRemainingHandlers = true; // 默认不阻断消息传递。如需阻断请删除注释
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Handlers/GroupMessageHandler.cs
+++ b/Mirai-CSharp.Example.Hosting/Handlers/GroupMessageHandler.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Mirai.CSharp.Builders;
+using Mirai.CSharp.HttpApi.Handlers;
+using Mirai.CSharp.HttpApi.Models.ChatMessages;
+using Mirai.CSharp.HttpApi.Models.EventArgs;
+using Mirai.CSharp.HttpApi.Parsers;
+using Mirai.CSharp.HttpApi.Parsers.Attributes;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting.Handlers
+{
+    [RegisterMiraiHttpParser(typeof(DefaultMappableMiraiHttpMessageParser<IGroupMessageEventArgs, GroupMessageEventArgs>))]
+    public sealed class GroupMessageHandler : IMiraiHttpMessageHandler<IGroupMessageEventArgs>
+    {
+        public async Task HandleMessageAsync(IMiraiHttpSession session, IGroupMessageEventArgs e) // 法3: 使用 IMessageBuilder
+        {
+            IMessageChainBuilder builder = session.GetMessageChainBuilder();
+            builder.AddPlainMessage($"收到了来自{e.Sender.Name}[{e.Sender.Id}]{{{e.Sender.Permission}}}的群消息:{string.Join(null, (IEnumerable<IChatMessage>)e.Chain)}");
+            //                                 / 发送者群名片 /  / 发送者QQ号 /   /   发送者在群内权限   /                                                       / 消息链 /
+            // builder.AddPlainMessage("QAQ").AddPlainMessage("OvO")/* .AddAtMessage(123456) etc... */;
+            await session.SendGroupMessageAsync(e.Sender.Group.Id, builder/*, plain2, /* etc... */); // 向消息来源群异步发送由以上chain表示的消息
+            // e.BlockRemainingHandlers = true; // 默认不阻断消息传递。如需阻断请删除注释
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Mirai-CSharp.Example.Hosting.csproj
+++ b/Mirai-CSharp.Example.Hosting/Mirai-CSharp.Example.Hosting.csproj
@@ -1,0 +1,13 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0</TargetFrameworks>
+    <RootNamespace>Mirai.CSharp.Example.Hosting</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Mirai-CSharp.HttpApi\Mirai-CSharp.HttpApi.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Mirai-CSharp.Example.Hosting/Program.cs
+++ b/Mirai-CSharp.Example.Hosting/Program.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.Hosting;
+
+namespace Mirai.CSharp.Example.Hosting
+{
+    public class Program
+    {
+        public static Task Main(string[] args)
+        {
+            return CreateHostBuilder(args).RunConsoleAsync();
+        }
+
+        public static IHostBuilder CreateHostBuilder(string[] args)
+        {
+            return Host.CreateDefaultBuilder(args)
+                       .ConfigureWebHostDefaults(webBuilder =>
+                       {
+                           webBuilder.UseStartup<Startup>();
+                       });
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Properties/launchSettings.json
+++ b/Mirai-CSharp.Example.Hosting/Properties/launchSettings.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "http://json.schemastore.org/launchsettings.json",
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:40870",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      }
+    },
+    "Mirai_CSharp.Example.Hosting": {
+      "commandName": "Project",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development"
+      },
+      "applicationUrl": "http://localhost:5000",
+      "dotnetRunMessages": "true"
+    }
+  }
+}

--- a/Mirai-CSharp.Example.Hosting/ResponseModel.cs
+++ b/Mirai-CSharp.Example.Hosting/ResponseModel.cs
@@ -1,0 +1,108 @@
+using System;
+using System.Runtime.CompilerServices;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Mirai.CSharp.Example.Hosting
+{
+    public class ResponseModel
+    {
+        protected static readonly ResponseModel _defaultSuccessModel = CreateFromStatusCode(0, "Success", Array.Empty<object>());
+
+        [JsonPropertyName("code")]
+        public int Code { get; set; }
+        [JsonPropertyName("msg")]
+        public string? Message { get; set; }
+        [JsonPropertyName("data")]
+        public object? Data { get; set; }
+
+        public ResponseModel() { }
+
+        public ResponseModel(int code, string? message = null, object? data = null)
+        {
+            Code = code;
+            Message = message;
+            Data = data ?? Array.Empty<object>();
+        }
+
+        public string GetJson(JsonSerializerOptions? options = null)
+            => JsonSerializer.Serialize(this, options);
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ResponseModel CreateFromStatusCode(int statusCode, string? message)
+            => CreateFromStatusCode(statusCode, message, Array.Empty<object>());
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static ResponseModel CreateFromStatusCode(int statusCode, string? message, object? data)
+            => new ResponseModel { Code = -statusCode, Message = message, Data = data };
+
+        public static ResponseModel CreateSuccess()
+            => _defaultSuccessModel;
+
+        public static ResponseModel CreateSuccess(string? message = "Success")
+            => CreateFromStatusCode(0, message, Array.Empty<object>());
+
+        public static ResponseModel CreateSuccess(string? message = "Success", object? data = null)
+            => CreateFromStatusCode(0, message, data);
+
+        public static ResponseModel CreateBadRequest()
+            => CreateFromStatusCode(400, "Bad request.", Array.Empty<object>());
+
+        public static ResponseModel CreateBadRequest(string? message = "Bad request.")
+            => CreateFromStatusCode(400, message, Array.Empty<object>());
+
+        public static ResponseModel CreateBadRequest(string? message = "Bad request.", object? data = null)
+            => CreateFromStatusCode(400, message, data);
+
+        public static ResponseModel CreateUnauthorized()
+            => CreateFromStatusCode(401, "Unauthorized.", Array.Empty<object>());
+
+        public static ResponseModel CreateUnauthorized(string? message = "Unauthorized.")
+            => CreateFromStatusCode(401, message, Array.Empty<object>());
+
+        public static ResponseModel CreateUnauthorized(string? message = "Unauthorized.", object? data = null)
+            => CreateFromStatusCode(401, message, data);
+
+        public static ResponseModel CreateForbidden()
+            => CreateFromStatusCode(403, "Forbidden.", Array.Empty<object>());
+
+        public static ResponseModel CreateForbidden(string? message = "Forbidden.")
+            => CreateFromStatusCode(403, message, Array.Empty<object>());
+
+        public static ResponseModel CreateForbidden(string? message = "Forbidden.", object? data = null)
+            => CreateFromStatusCode(403, message, data);
+
+        public static ResponseModel CreateNotFound()
+            => CreateFromStatusCode(404, "Not found.", Array.Empty<object>());
+
+        public static ResponseModel CreateNotFound(string? message = "Not found.")
+            => CreateFromStatusCode(404, message, Array.Empty<object>());
+
+        public static ResponseModel CreateNotFound(string? message = "Not found.", object? data = null)
+            => CreateFromStatusCode(404, message, data);
+
+        public static ResponseModel CreateInternalServerError()
+            => CreateFromStatusCode(500, "Internal server error.", Array.Empty<object>());
+
+        public static ResponseModel CreateInternalServerError(string? message = "Internal server error.")
+            => CreateFromStatusCode(500, message, Array.Empty<object>());
+
+        public static ResponseModel CreateInternalServerError(string? message = "Internal server error.", object? data = null)
+            => CreateFromStatusCode(500, message, data);
+
+        public static ResponseModel CreateServiceUnavailable()
+            => CreateFromStatusCode(503, "Service unavailable.", Array.Empty<object>());
+
+        public static ResponseModel CreateServiceUnavailable(string? message = "Service unavailable.")
+            => CreateFromStatusCode(503, message, Array.Empty<object>());
+
+        public static ResponseModel CreateServiceUnavailable(string? message = "Service unavailable.", object? data = null)
+            => CreateFromStatusCode(503, message, data);
+
+        public static explicit operator JsonResult(ResponseModel model)
+        {
+            return new JsonResult(model);
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Services/RobotManager.cs
+++ b/Mirai-CSharp.Example.Hosting/Services/RobotManager.cs
@@ -1,0 +1,86 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting.Services
+{
+    public sealed class RobotManager
+    {
+        private readonly IServiceProvider _services;
+
+        private readonly ConcurrentDictionary<long, IServiceScope> _robotScopes;
+
+        private readonly ConcurrentDictionary<long, TaskCompletionSource<Task<IMiraiHttpSession>>> _robotInitTasks;
+
+        public RobotManager(IServiceProvider services)
+        {
+            _services = services;
+            _robotScopes = new ConcurrentDictionary<long, IServiceScope>();
+            _robotInitTasks = new ConcurrentDictionary<long, TaskCompletionSource<Task<IMiraiHttpSession>>>();
+        }
+
+        public ValueTask<IMiraiHttpSession> RetriveSessionAsync(long robotQQ, CancellationToken token = default)
+        {
+            while (true)
+            {
+                if (_robotScopes.TryGetValue(robotQQ, out IServiceScope? session))
+                {
+                    return new ValueTask<IMiraiHttpSession>(session.ServiceProvider.GetRequiredService<IMiraiHttpSession>());
+                }
+                if (_robotInitTasks.TryGetValue(robotQQ, out TaskCompletionSource<Task<IMiraiHttpSession>>? actualTcs))
+                {
+                    return new ValueTask<IMiraiHttpSession>(actualTcs.Task.Unwrap());
+                }
+                TaskCompletionSource<Task<IMiraiHttpSession>> createdTcs = new TaskCompletionSource<Task<IMiraiHttpSession>>();
+                if (!_robotInitTasks.TryAdd(robotQQ, createdTcs))
+                {
+                    continue;
+                }
+                Task<IMiraiHttpSession> task = InternalRetriveSessionAsync(robotQQ, token);
+                createdTcs.SetResult(task);
+                return new ValueTask<IMiraiHttpSession>(task);
+            }
+        }
+
+        private async Task<IMiraiHttpSession> InternalRetriveSessionAsync(long robotQQ, CancellationToken token)
+        {
+            try
+            {
+                if (_robotScopes.TryGetValue(robotQQ, out IServiceScope? dualcheck))
+                {
+                    return dualcheck.ServiceProvider.GetRequiredService<IMiraiHttpSession>();
+                }
+                IServiceScope scope = _services.CreateScope();
+                try
+                {
+                    IMiraiHttpSession session = scope.ServiceProvider.GetRequiredService<IMiraiHttpSession>();
+                    await session.ConnectAsync(robotQQ, token).ConfigureAwait(false);
+                    _robotScopes[robotQQ] = scope;
+                    return session;
+                }
+                catch
+                {
+                    scope.Dispose();
+                    throw;
+                }
+            }
+            finally
+            {
+                _robotInitTasks.TryRemove(robotQQ, out _);
+            }
+        }
+
+        public bool RemoveSession(long robotQQ)
+        {
+            if (!_robotScopes.TryRemove(robotQQ, out IServiceScope? scope))
+            {
+                return false;
+            }
+            scope.Dispose();
+            return true;
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/Startup.cs
+++ b/Mirai-CSharp.Example.Hosting/Startup.cs
@@ -1,0 +1,51 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Mirai.CSharp.Example.Hosting.Handlers;
+using Mirai.CSharp.Example.Hosting.Services;
+using Mirai.CSharp.HttpApi.Builder;
+using Mirai.CSharp.HttpApi.Invoking;
+using Mirai.CSharp.HttpApi.Options;
+using Mirai.CSharp.HttpApi.Session;
+
+namespace Mirai.CSharp.Example.Hosting
+{
+    public class Startup
+    {
+        public void ConfigureServices(IServiceCollection services)
+        {
+            services.AddControllers();
+
+            services.AddDefaultMiraiHttpFramework()
+                    .ResolveParser<GroupMessageHandler>() // 需要动态添加的 Handler 放这里
+                    .ResolveParser<FriendMessageHandler>() // 默认的生命周期是 Singleton
+                    .AddInvoker<MiraiHttpMessageHandlerInvoker>() // 自此以下的默认的生命周期是 Scoped
+                    .AddHandler<DefaultDisconnectedHandler>(ServiceLifetime.Singleton) // 静态解析的 Handler 放这里。解析时机为 IMiraiHttpSession 被解析时
+                    .AddHandler<AutoRejectFriendApplyHandler>()
+                    .AddClient<MiraiHttpSession>();
+
+            services.AddSingleton<RobotManager>();
+
+            services.Configure<MiraiHttpSessionOptions>(options =>
+            {
+                options.Host = "";
+                options.Port = 0; // 端口
+                options.AuthKey = "0"; // 凭据
+            });
+        }
+
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env)
+        {
+            if (env.IsDevelopment())
+            {
+                app.UseDeveloperExceptionPage();
+            }
+            app.UseRouting();
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+    }
+}

--- a/Mirai-CSharp.Example.Hosting/appsettings.Development.json
+++ b/Mirai-CSharp.Example.Hosting/appsettings.Development.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  }
+}

--- a/Mirai-CSharp.Example.Hosting/appsettings.json
+++ b/Mirai-CSharp.Example.Hosting/appsettings.json
@@ -1,0 +1,10 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "AllowedHosts": "*"
+}

--- a/Mirai-CSharp.HttpApi/Mirai-CSharp.HttpApi.csproj
+++ b/Mirai-CSharp.HttpApi/Mirai-CSharp.HttpApi.csproj
@@ -14,6 +14,11 @@
     <PackageReference Include="System.Text.Json" Version="5.0.2" />
   </ItemGroup>
 
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
+    <PackageReference Include="System.Reflection.Emit" Version="4.7.0" />
+    <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.7.0" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="SkiaSharp" Version="2.80.3" />
   </ItemGroup>

--- a/Mirai-CSharp.sln
+++ b/Mirai-CSharp.sln
@@ -27,6 +27,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mirai-CSharp.NativeAssets.L
 		Mirai-CSharp.NativeAssets.Linux\Mirai-CSharp.NativeAssets.Linux.props = Mirai-CSharp.NativeAssets.Linux\Mirai-CSharp.NativeAssets.Linux.props
 	EndProjectSection
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Mirai-CSharp.Example.Hosting", "Mirai-CSharp.Example.Hosting\Mirai-CSharp.Example.Hosting.csproj", "{5679DB58-8369-408C-A607-8C7BC1A76D69}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -45,6 +47,10 @@ Global
 		{5CE67FE5-11C0-4A0F-9736-9311383B66D0}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5CE67FE5-11C0-4A0F-9736-9311383B66D0}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5CE67FE5-11C0-4A0F-9736-9311383B66D0}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5679DB58-8369-408C-A607-8C7BC1A76D69}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5679DB58-8369-408C-A607-8C7BC1A76D69}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5679DB58-8369-408C-A607-8C7BC1A76D69}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5679DB58-8369-408C-A607-8C7BC1A76D69}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Mirai-CSharp/Session/MiraiSession.SendMessage.cs
+++ b/Mirai-CSharp/Session/MiraiSession.SendMessage.cs
@@ -60,13 +60,13 @@ namespace Mirai.CSharp.Session
         /// <inheritdoc/>
         public virtual Task<int> SendTempMessageAsync(long qqNumber, long groupNumber, params IChatMessage[] chain)
         {
-            return SendTempMessageAsync(qqNumber, qqNumber, chain, default);
+            return SendTempMessageAsync(qqNumber, groupNumber, chain, default);
         }
 
         /// <inheritdoc/>
         public virtual Task<int> SendTempMessageAsync(long qqNumber, long groupNumber, IChatMessage[] chain, CancellationToken token = default)
         {
-            return SendTempMessageAsync(qqNumber, qqNumber, chain, null, default);
+            return SendTempMessageAsync(qqNumber, groupNumber, chain, null, default);
         }
 
         /// <inheritdoc/>
@@ -75,7 +75,7 @@ namespace Mirai.CSharp.Session
         /// <inheritdoc/>
         public virtual Task<int> SendTempMessageAsync(long qqNumber, long groupNumber, IMessageChainBuilder builder, CancellationToken token = default)
         {
-            return SendTempMessageAsync(qqNumber, qqNumber, builder, null, default);
+            return SendTempMessageAsync(qqNumber, groupNumber, builder, null, default);
         }
 
         /// <inheritdoc/>


### PR DESCRIPTION
close #125 
close #128 

- 修复在发送临时消息的时候错误提供参数的问题
- 简单做一个 ASP.NET Core 的示例
- 使用Emit调用 `JsonDocument.GetRawdata` 方法