### PR TITLE
更新至v2.1.7

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,10 +9,10 @@
     <PropertyGroup>
         <OutputType>Library</OutputType>
         <NoWin32Manifest>true</NoWin32Manifest>
-        <Version>2.1.6.0</Version>
-        <AssemblyVersion>2.1.6.0</AssemblyVersion>
-        <FileVersion>2.1.6.0</FileVersion>
-        <PackageVersion>2.1.6.0</PackageVersion>
+        <Version>2.1.7.0</Version>
+        <AssemblyVersion>2.1.7.0</AssemblyVersion>
+        <FileVersion>2.1.7.0</FileVersion>
+        <PackageVersion>2.1.7.0</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.SendImage.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.SendImage.cs
@@ -80,6 +80,7 @@ namespace Mirai.CSharp.HttpApi.Session
                 internalStream = new MemoryStream(8192);
                 internalCreated = true;
                 await imgStream.CopyToAsync(internalStream, 81920, token);
+                internalStream.Seek(0, SeekOrigin.Begin);
             }
             else // 否则不创建副本, 避免多余的堆分配
             {

--- a/Mirai-CSharp/Session/MiraiSession.cs
+++ b/Mirai-CSharp/Session/MiraiSession.cs
@@ -8,9 +8,15 @@ namespace Mirai.CSharp.Session
         /// <inheritdoc/>
         public abstract IMessageChainBuilder GetMessageChainBuilder();
 
-        public abstract void Dispose(bool disposing);
+        protected virtual void Dispose(bool disposing)
+        {
+            
+        }
 
-        public virtual void Dispose()
+        /// <summary>
+        /// 释放当前会话所用资源
+        /// </summary>
+        public void Dispose()
         {
             Dispose(true);
             GC.SuppressFinalize(this);


### PR DESCRIPTION
close #130 

- 修复上传图片时,先行缓存至内部缓冲流将导致SKCodec创建失败的问题
- 标准化 `Dispose` / `DisposeAsync` 模式
> 访问修饰符已更改 (`MiraiSession.Dispose(bool)` -> `protected`)
> `MiraiSession.Dispose()` 方法改为实方法
> `MiraiSession.Dispose(bool)` 改为空方法体的虚方法