### PR TITLE
更新至v2.1.8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -339,3 +339,4 @@ ASALocalRun/
 # BeatPulse healthcheck temp database
 healthchecksdb
 /Mirai-CSharp/Mirai-CSharp.xml
+*.wakatime-project

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -10,9 +10,9 @@
         <OutputType>Library</OutputType>
         <NoWin32Manifest>true</NoWin32Manifest>
         <Version>2.1.7.0</Version>
-        <AssemblyVersion>2.1.7.0</AssemblyVersion>
-        <FileVersion>2.1.7.0</FileVersion>
-        <PackageVersion>2.1.7.0</PackageVersion>
+        <AssemblyVersion>2.1.8.0</AssemblyVersion>
+        <FileVersion>2.1.8.0</FileVersion>
+        <PackageVersion>2.1.8</PackageVersion>
         <Nullable>enable</Nullable>
         <LangVersion>preview</LangVersion>
         <Authors>Executor</Authors>

--- a/Mirai-CSharp.HttpApi/Builder/ForwardMessageBuilder.cs
+++ b/Mirai-CSharp.HttpApi/Builder/ForwardMessageBuilder.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections.Generic;
+using Mirai.CSharp.HttpApi.Models.ChatMessages;
+using ISharedChatMessage = Mirai.CSharp.Models.ChatMessages.IChatMessage;
+using ISharedForwardMessage = Mirai.CSharp.Models.ChatMessages.IForwardMessage;
+using ISharedForwardMessageBuilder = Mirai.CSharp.Builders.IForwardMessageBuilder;
+using ISharedForwardMessageNode = Mirai.CSharp.Models.ChatMessages.IForwardMessageNode;
+using ISharedMessageChainBuilder = Mirai.CSharp.Builders.IMessageChainBuilder;
+using SharedForwardMessageBuilder = Mirai.CSharp.Builders.ForwardMessageBuilder;
+
+namespace Mirai.CSharp.HttpApi.Builders
+{
+    public interface IForwardMessageBuilder : ISharedForwardMessageBuilder
+    {
+
+    }
+
+    public class ForwardMessageBuilder : SharedForwardMessageBuilder, IForwardMessageBuilder
+    {
+        public override ISharedForwardMessage Build()
+        {
+            IForwardMessageNode[] converted = new ForwardMessageNode[_nodes.Count];
+            int ix = 0;
+            foreach (var node in _nodes)
+            {
+                converted[ix++] = (IForwardMessageNode)node;
+            }
+            return new ForwardMessage(converted);
+        }
+
+        public override ISharedForwardMessageBuilder AddNode(ISharedForwardMessageNode node)
+        {
+            if (node is not IForwardMessageNode)
+            {
+                throw new InvalidOperationException($"添加的消息实例 {node.GetType().FullName} 不实现 {typeof(IForwardMessageNode).FullName}");
+            }
+            return base.AddNode(node);
+        }
+
+        public override ISharedForwardMessageBuilder AddNodes(IEnumerable<ISharedForwardMessageNode> nodes)
+        {
+            foreach (ISharedForwardMessageNode node in nodes)
+            {
+                if (node is not IForwardMessageNode)
+                {
+                    throw new InvalidOperationException($"添加的消息实例 {node.GetType().FullName} 不实现 {typeof(IChatMessage).FullName}");
+                }
+            }
+            return base.AddNodes(nodes);
+        }
+
+        public override ISharedForwardMessageBuilder AddNode(int id)
+        {
+            _nodes.Add(new ForwardMessageNode(id));
+            return this;
+        }
+
+        public override ISharedForwardMessageBuilder AddNode(string name, long qqNumber, DateTime time, ISharedMessageChainBuilder chainBuilder)
+        {
+            return AddNode(name, qqNumber, time, chainBuilder.Build());
+        }
+
+        public override ISharedForwardMessageBuilder AddNode(string name, long qqNumber, DateTime time, params ISharedChatMessage[] messages)
+        {
+            if (messages is not IChatMessage[] converted)
+            {
+                converted = new IChatMessage[messages.Length];
+                int ix = 0;
+                foreach (var message in messages)
+                {
+                    if (message is not IChatMessage chatMessage)
+                    {
+                        throw new InvalidOperationException($"添加的消息实例 {message.GetType().FullName} 不实现 {typeof(IChatMessage).FullName}");
+                    }
+                    converted[ix++] = chatMessage;
+                }
+            }
+            _nodes.Add(new ForwardMessageNode(name, qqNumber, time, converted));
+            return this;
+        }
+    }
+
+    public class ImmutableForwardMessageBuilder : ForwardMessageBuilder
+    {
+        protected ISharedForwardMessage? _builtMessage;
+
+        public override ISharedForwardMessage Build()
+        {
+            if (_builtMessage == null)
+            {
+                _builtMessage = base.Build();
+                _nodes.Clear();
+                _nodes.Capacity = 0;
+            }
+            return _builtMessage;
+        }
+
+        public override ISharedForwardMessageBuilder AddNode(ISharedForwardMessageNode node)
+        {
+            if (_builtMessage != null)
+            {
+                throw new InvalidOperationException("由于之前进行过构建操作, 无法添加新的消息节点实例");
+            }
+            return base.AddNode(node);
+        }
+
+        public override ISharedForwardMessageBuilder AddNodes(IEnumerable<ISharedForwardMessageNode> nodes)
+        {
+            if (_builtMessage != null)
+            {
+                throw new InvalidOperationException("由于之前进行过构建操作, 无法添加新的消息节点实例");
+            }
+            return base.AddNodes(nodes);
+        }
+    }
+}

--- a/Mirai-CSharp.HttpApi/Mirai-CSharp.HttpApi.csproj
+++ b/Mirai-CSharp.HttpApi/Mirai-CSharp.HttpApi.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <RootNamespace>Mirai.CSharp.HttpApi</RootNamespace>
@@ -23,12 +23,9 @@
     <PackageReference Include="SkiaSharp" Version="2.80.3" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(NETCoreSdkRuntimeIdentifier)' == 'win-x86' or '$(NETCoreSdkRuntimeIdentifier)' == 'win-x64'">
-    <PackageReference Include="Mirai-CSharp.NativeAssets.Win32" Version="1.0.2"/>
-  </ItemGroup>
-
-  <ItemGroup Condition="'$(NETCoreSdkRuntimeIdentifier)' == 'linux-x64'">
-    <PackageReference Include="Mirai-CSharp.NativeAssets.Linux" Version="1.0.2"/>
+  <ItemGroup>
+    <PackageReference Condition="'$(NETCoreSdkRuntimeIdentifier)' == 'win-x86' or '$(NETCoreSdkRuntimeIdentifier)' == 'win-x64'" Include="Mirai-CSharp.NativeAssets.Win32" Version="1.0.2"/>
+    <PackageReference Condition="'$(NETCoreSdkRuntimeIdentifier)' == 'linux-x64'" Include="Mirai-CSharp.NativeAssets.Linux" Version="1.0.2"/>
   </ItemGroup>
 
 </Project>

--- a/Mirai-CSharp.HttpApi/Models/ChatMessages/ForwardMessage.cs
+++ b/Mirai-CSharp.HttpApi/Models/ChatMessages/ForwardMessage.cs
@@ -13,11 +13,11 @@ namespace Mirai.CSharp.HttpApi.Models.ChatMessages
     public interface IForwardMessage : ISharedForwardMessage, IChatMessage
     {
         [JsonPropertyName("nodeList")]
-        [JsonConverter(typeof(ChangeTypeJsonConverter<ForwardMessageNode[], IForwardMessageNode[]>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IForwardMessageNode[], object[], ForwardMessageNode[]>))]
         new IForwardMessageNode[] Nodes { get; }
 
 #if !NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<ForwardMessageNode[], ISharedForwardMessageNode[]>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedForwardMessageNode[], object[], ForwardMessageNode[]>))]
         [JsonPropertyName("nodeList")]
         ISharedForwardMessageNode[] ISharedForwardMessage.Nodes => Nodes;
 #endif
@@ -36,7 +36,7 @@ namespace Mirai.CSharp.HttpApi.Models.ChatMessages
         /// <summary>
         /// 转发的消息数组
         /// </summary>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<ForwardMessageNode[], IForwardMessageNode[]>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IForwardMessageNode[], object[], ForwardMessageNode[]>))]
         [JsonPropertyName("nodeList")]
         public IForwardMessageNode[] Nodes { get; set; } = null!;
 
@@ -57,7 +57,7 @@ namespace Mirai.CSharp.HttpApi.Models.ChatMessages
         }
 
 #if NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<ForwardMessageNode[], ISharedForwardMessageNode[]>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedForwardMessageNode[], object[], ForwardMessageNode[]>))]
         [JsonPropertyName("nodeList")]
         ISharedForwardMessageNode[] ISharedForwardMessage.Nodes => Nodes;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/ChatMessages/ForwardMessageNode.cs
+++ b/Mirai-CSharp.HttpApi/Models/ChatMessages/ForwardMessageNode.cs
@@ -61,6 +61,24 @@ namespace Mirai.CSharp.HttpApi.Models.ChatMessages
         [JsonPropertyName("messageChain")]
         public IChatMessage[] Chain { get; set; } = null!;
 
+        public ForwardMessageNode()
+        {
+
+        }
+
+        public ForwardMessageNode(int id)
+        {
+            Id = id;
+        }
+
+        public ForwardMessageNode(string name, long qQNumber, DateTime time, IChatMessage[] chain)
+        {
+            Name = name;
+            QQNumber = qQNumber;
+            Time = time;
+            Chain = chain;
+        }
+
         public override string ToString()
         {
             return $"[mirai:forward:{Chain.Length} nodes]";

--- a/Mirai-CSharp.HttpApi/Models/ChatMessages/MarketFaceMessaage.cs
+++ b/Mirai-CSharp.HttpApi/Models/ChatMessages/MarketFaceMessaage.cs
@@ -12,10 +12,10 @@ namespace Mirai.CSharp.HttpApi.Models.ChatMessages
     public interface IMarketFaceMessage : ISharedMarketFaceMessage, IChatMessage
     {
 #if NETSTANDARD2_0
-        /// <inheritdoc cref="ISharedMarketFaceMessaage.Id"/>
+        /// <inheritdoc cref="ISharedMarketFaceMessage.Id"/>
         [JsonPropertyName("id")]
         new int Id { get; }
-        /// <inheritdoc cref="ISharedMarketFaceMessaage.Name"/>
+        /// <inheritdoc cref="ISharedMarketFaceMessage.Name"/>
         [JsonPropertyName("name")]
         new string Name { get; }
 #else

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotJoinedGroupEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Bot/BotJoinedGroupEventArgs.cs
@@ -22,7 +22,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public class BotJoinedGroupEventArgs : GroupEventArgs, IBotJoinedGroupEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("invitor")]
         public IGroupMemberInfo? Inviter { get; set; }
 
@@ -40,7 +40,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("invitor")]
         ISharedGroupMemberInfo? ISharedInviterEventArgs.Inviter => Inviter;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Friend/FriendEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Friend/FriendEventArgs.cs
@@ -9,12 +9,12 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public interface IFriendEventArgs : ISharedJsonFriendEventArgs, IMiraiHttpMessage
     {
         [JsonPropertyName("friend")]
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, IFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IFriendInfo, FriendInfo>))]
         new IFriendInfo Friend { get; }
 
 #if !NETSTANDARD2_0
         [JsonPropertyName("friend")]
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, ISharedFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedFriendInfo, FriendInfo>))]
         ISharedFriendInfo ISharedFriendEventArgs.Friend => Friend;
 #endif
     }
@@ -22,7 +22,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class FriendEventArgs : MiraiHttpMessage, IFriendEventArgs
     {
         [JsonPropertyName("friend")]
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, IFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IFriendInfo, FriendInfo>))]
         public IFriendInfo Friend { get; set; } = null!;
 
         protected FriendEventArgs()
@@ -37,7 +37,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         [JsonPropertyName("friend")]
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, ISharedFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedFriendInfo, FriendInfo>))]
         ISharedFriendInfo ISharedFriendEventArgs.Friend => Friend;
 #endif
     }

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Friend/FriendMessageEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Friend/FriendMessageEventArgs.cs
@@ -17,7 +17,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public interface IFriendMessageEventArgs : ISharedJsonFriendMessageEventArgs, ICommonMessageEventArgs
     {
         /// <inheritdoc cref="ISharedFriendMessageEventArgs.Sender"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, IFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IFriendInfo, FriendInfo>))]
         [JsonPropertyName("sender")]
         new IFriendInfo Sender { get; }
 
@@ -29,7 +29,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public class FriendMessageEventArgs : CommonMessageEventArgs, IFriendMessageEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<FriendInfo, IFriendInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IFriendInfo, FriendInfo>))]
         [JsonPropertyName("sender")]
         public IFriendInfo Sender { get; set; } = null!;
 

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/BotGroupPropertyChangedEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/BotGroupPropertyChangedEventArgs.cs
@@ -22,7 +22,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         /// <summary>
         /// 机器人所在群信息
         /// </summary>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         public IGroupInfo Group { get; set; } = null!;
 
@@ -35,7 +35,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupEventArgs.Group => Group;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupEventArgs.cs
@@ -20,13 +20,13 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public interface IGroupEventArgs : ISharedJsonGroupEventArgs, IMiraiHttpMessage
     {
         /// <inheritdoc cref="ISharedGroupEventArgs.Group"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         new IGroupInfo Group { get; }
 
 #if !NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupEventArgs.Group => Group;
 #endif
@@ -35,7 +35,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class GroupEventArgs : MiraiHttpMessage, IGroupEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         public IGroupInfo Group { get; set; } = null!;
 
@@ -50,7 +50,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupEventArgs.Group => Group;
 #endif
@@ -60,13 +60,13 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public interface IMemberEventArgs : ISharedJsonMemberEventArgs, IMiraiHttpMessage
     {
         /// <inheritdoc cref="ISharedMemberEventArgs.Member"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         new IGroupMemberInfo Member { get; }
 
 #if !NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         ISharedGroupMemberInfo ISharedMemberEventArgs.Member => Member;
 #endif
@@ -75,7 +75,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class MemberEventArgs : MiraiHttpMessage, IMemberEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         public IGroupMemberInfo Member { get; set; } = null!;
 
@@ -90,7 +90,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         ISharedGroupMemberInfo ISharedMemberEventArgs.Member => Member;
 #endif
@@ -100,13 +100,13 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public interface IOperatorEventArgs : ISharedJsonOperatorEventArgs, IMiraiHttpMessage
     {
         /// <inheritdoc cref="ISharedOperatorEventArgs.Operator"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         new IGroupMemberInfo Operator { get; }
 
 #if !NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         ISharedGroupMemberInfo ISharedOperatorEventArgs.Operator => Operator;
 #endif
@@ -115,7 +115,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class OperatorEventArgs : MiraiHttpMessage, IOperatorEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         public virtual IGroupMemberInfo Operator { get; set; } = null!;
 
@@ -130,7 +130,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         ISharedGroupMemberInfo ISharedOperatorEventArgs.Operator => Operator;
 #endif
@@ -147,7 +147,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public class GroupOperatingEventArgs : OperatorEventArgs, IGroupOperatingEventArgs // 没法继承多个类, 强转接口吧
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         public IGroupInfo Group { get; set; } = null!;
 
@@ -162,7 +162,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupEventArgs.Group => Group;
 #endif
@@ -179,7 +179,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class MemberOperatingEventArgs : OperatorEventArgs, IMemberOperatingEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         public IGroupMemberInfo Member { get; set; } = null!;
 
@@ -194,7 +194,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         ISharedGroupMemberInfo ISharedMemberEventArgs.Member => Member;
 #endif
@@ -211,13 +211,13 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         /// <remarks>
         /// 仅当 mirai-api-http 版本至少为 2.3.0 时, 此属性可能不为 <see langword="null"/>
         /// </remarks>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("invitor")]
         new IGroupMemberInfo? Inviter { get; }
 
 #if !NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("invitor")]
         ISharedGroupMemberInfo? ISharedInviterEventArgs.Inviter => Inviter;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupMemberPropertyChangedEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupMemberPropertyChangedEventArgs.cs
@@ -23,7 +23,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         /// <summary>
         /// 被操作者信息
         /// </summary>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         public IGroupMemberInfo Member { get; set; } = null!;
 
@@ -38,7 +38,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         ISharedGroupMemberInfo ISharedMemberEventArgs.Member => Member;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupMessageBaseEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupMessageBaseEventArgs.cs
@@ -14,12 +14,12 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public interface IGroupMessageBaseEventArgs : ISharedJsonElementGroupMessageBaseEventArgs, ICommonMessageEventArgs
     {
         /// <inheritdoc cref="ISharedGroupMessageBaseEventArgs.Sender"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("sender")]
         new IGroupMemberInfo Sender { get; }
 
 #if !NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("sender")]
         ISharedGroupMemberInfo ISharedGroupMessageBaseEventArgs.Sender => Sender;
 #endif
@@ -28,7 +28,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public abstract class GroupMessageBaseEventArgs : CommonMessageEventArgs, IGroupMessageBaseEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("sender")]
         public IGroupMemberInfo Sender { get; set; } = null!;
 
@@ -44,7 +44,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("sender")]
         ISharedGroupMemberInfo ISharedGroupMessageBaseEventArgs.Sender => Sender;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupMessageRevokedEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupMessageRevokedEventArgs.cs
@@ -2,11 +2,13 @@ using System;
 using System.Text.Json.Serialization;
 using Mirai.CSharp.HttpApi.Parsers.Attributes;
 using Mirai.CSharp.HttpApi.Utility.JsonConverters;
+using ISharedGroupMessageRevokedEventArgs = Mirai.CSharp.Models.EventArgs.IGroupMessageRevokedEventArgs<System.Text.Json.JsonElement>;
+#if NETSTANDARD2_0
 using ISharedGroupEventArgs = Mirai.CSharp.Models.EventArgs.IGroupEventArgs;
 using ISharedGroupInfo = Mirai.CSharp.Models.IGroupInfo;
 using ISharedGroupMemberInfo = Mirai.CSharp.Models.IGroupMemberInfo;
-using ISharedGroupMessageRevokedEventArgs = Mirai.CSharp.Models.EventArgs.IGroupMessageRevokedEventArgs<System.Text.Json.JsonElement>;
 using ISharedOperatorEventArgs = Mirai.CSharp.Models.EventArgs.IOperatorEventArgs;
+#endif
 
 namespace Mirai.CSharp.HttpApi.Models.EventArgs
 {
@@ -24,11 +26,11 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         /// <summary>
         /// 被撤回消息所在群信息
         /// </summary>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         public IGroupInfo Group { get; set; } = null!;
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         public IGroupMemberInfo Operator { get; set; } = null!;
 
@@ -44,11 +46,11 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupEventArgs.Group => Group;
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("member")]
         ISharedGroupMemberInfo ISharedOperatorEventArgs.Operator => Operator;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupPropertyChangedEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/GroupPropertyChangedEventArgs.cs
@@ -23,7 +23,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
         /// <summary>
         /// 操作者信息
         /// </summary>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         public IGroupMemberInfo Operator { get; set; } = null!;
 
@@ -38,7 +38,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("operator")]
         ISharedGroupMemberInfo ISharedOperatorEventArgs.Operator => Operator;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Group/Specialized/GroupMemberJoinedEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Group/Specialized/GroupMemberJoinedEventArgs.cs
@@ -22,7 +22,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
     public class GroupMemberJoinedEventArgs : MemberEventArgs, IGroupMemberJoinedEventArgs
     {
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, IGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("invitor")]
         public IGroupMemberInfo? Inviter { get; set; }
 
@@ -40,7 +40,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs
 
 #if NETSTANDARD2_0
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupMemberInfo, ISharedGroupMemberInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupMemberInfo, GroupMemberInfo>))]
         [JsonPropertyName("invitor")]
         ISharedGroupMemberInfo? ISharedInviterEventArgs.Inviter => Inviter;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/EventArgs/Stranger/StrangerMessageEventArgs.cs
+++ b/Mirai-CSharp.HttpApi/Models/EventArgs/Stranger/StrangerMessageEventArgs.cs
@@ -14,12 +14,12 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs.Stranger
     [MappableMiraiHttpMessageKey("StrangerMessage")]
     public interface IStrangerMessageEventArgs : ISharedJsonElementStrangerMessageEventArgs, ICommonMessageEventArgs
     {
-        [JsonConverter(typeof(ChangeTypeJsonConverter<StrangerInfo, IStrangerInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IStrangerInfo, StrangerInfo>))]
         [JsonPropertyName("sender")]
         new IStrangerInfo Sender { get; }
 
 #if !NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<StrangerInfo, ISharedStrangerInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedStrangerInfo, StrangerInfo>))]
         [JsonPropertyName("sender")]
         ISharedStrangerInfo ISharedStrangerMessageEventArgs.Sender => Sender;
 #endif
@@ -27,7 +27,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs.Stranger
 
     public class StrangerMessageEventArgs : CommonMessageEventArgs, IStrangerMessageEventArgs
     {
-        [JsonConverter(typeof(ChangeTypeJsonConverter<StrangerInfo, IStrangerInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IStrangerInfo, StrangerInfo>))]
         [JsonPropertyName("sender")]
         public IStrangerInfo Sender { get; set; } = null!;
 
@@ -42,7 +42,7 @@ namespace Mirai.CSharp.HttpApi.Models.EventArgs.Stranger
         }
 
 #if NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<StrangerInfo, ISharedStrangerInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedStrangerInfo, StrangerInfo>))]
         [JsonPropertyName("sender")]
         ISharedStrangerInfo ISharedStrangerMessageEventArgs.Sender => Sender;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/GroupAnnouncement.cs
+++ b/Mirai-CSharp.HttpApi/Models/GroupAnnouncement.cs
@@ -56,12 +56,12 @@ namespace Mirai.CSharp.HttpApi.Models
         abstract DateTime ISharedGroupAnnouncement.CreateTime { get; }
 #endif
         /// <inheritdoc cref="ISharedGroupAnnouncement.Group"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         new IGroupInfo Group { get; }
 
 #if !NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupAnnouncement.Group => Group;
 #endif
@@ -139,7 +139,7 @@ namespace Mirai.CSharp.HttpApi.Models
         [JsonPropertyName("publicationTime")]
         DateTime ISharedGroupAnnouncement.CreateTime => CreateTime;
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupAnnouncement.Group => Group;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/GroupFileInfo.cs
+++ b/Mirai-CSharp.HttpApi/Models/GroupFileInfo.cs
@@ -10,17 +10,17 @@ namespace Mirai.CSharp.HttpApi.Models
     public interface IGroupFileInfo : ISharedGroupFileInfo
     {
         /// <inheritdoc cref="ISharedGroupFileInfo.Parent"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileInfo, IGroupFileInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupFileInfo, GroupFileInfo>))]
         [JsonPropertyName("parent")]
         new IGroupFileInfo? Parent { get; }
 
         /// <inheritdoc cref="ISharedGroupFileInfo.Group"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("contact")]
         new IGroupInfo Group { get; }
 
         /// <inheritdoc cref="ISharedGroupFileInfo.DownloadInfo"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileDownloadInfo, IGroupFileDownloadInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupFileDownloadInfo, GroupFileDownloadInfo>))]
         [JsonPropertyName("parent")]
         new IGroupFileDownloadInfo? DownloadInfo { get; }
 
@@ -60,15 +60,15 @@ namespace Mirai.CSharp.HttpApi.Models
         [JsonPropertyName("isDirectory")]
         abstract bool ISharedGroupFileInfo.IsDirectory { get; }
 
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileInfo, ISharedGroupFileInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupFileInfo, GroupFileInfo>))]
         [JsonPropertyName("parent")]
         ISharedGroupFileInfo? ISharedGroupFileInfo.Parent => Parent;
 
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("contact")]
         ISharedGroupInfo ISharedGroupFileInfo.Group => Group;
 
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileDownloadInfo, ISharedGroupFileDownloadInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupFileDownloadInfo, GroupFileDownloadInfo>))]
         [JsonPropertyName("downloadInfo")]
         ISharedGroupFileDownloadInfo? ISharedGroupFileInfo.DownloadInfo => DownloadInfo;
 #endif
@@ -89,12 +89,12 @@ namespace Mirai.CSharp.HttpApi.Models
         public string Path { get; set; } = null!;
 
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileInfo, IGroupFileInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupFileInfo, GroupFileInfo>))]
         [JsonPropertyName("parent")]
         public IGroupFileInfo? Parent { get; set; }
 
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("contact")]
         public IGroupInfo Group { get; set; } = null!;
 
@@ -107,7 +107,7 @@ namespace Mirai.CSharp.HttpApi.Models
         public bool IsDirectory { get; set; }
 
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileDownloadInfo, IGroupFileDownloadInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupFileDownloadInfo, GroupFileDownloadInfo>))]
         [JsonPropertyName("downloadInfo")]
         public IGroupFileDownloadInfo? DownloadInfo { get; set; }
 
@@ -129,15 +129,15 @@ namespace Mirai.CSharp.HttpApi.Models
         }
 
 #if NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileInfo, ISharedGroupFileInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupFileInfo, GroupFileInfo>))]
         [JsonPropertyName("parent")]
         ISharedGroupFileInfo? ISharedGroupFileInfo.Parent => Parent;
 
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("contact")]
         ISharedGroupInfo ISharedGroupFileInfo.Group => Group;
 
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupFileDownloadInfo, ISharedGroupFileDownloadInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupFileDownloadInfo, GroupFileDownloadInfo>))]
         [JsonPropertyName("downloadInfo")]
         ISharedGroupFileDownloadInfo? ISharedGroupFileInfo.DownloadInfo => DownloadInfo;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/GroupMemberInfo.cs
+++ b/Mirai-CSharp.HttpApi/Models/GroupMemberInfo.cs
@@ -65,12 +65,12 @@ namespace Mirai.CSharp.HttpApi.Models
 #endif
 
         /// <inheritdoc cref="ISharedGroupMemberInfo.Group"/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         new IGroupInfo Group { get; }
 
 #if !NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupMemberInfo.Group => Group;
 #endif
@@ -83,7 +83,7 @@ namespace Mirai.CSharp.HttpApi.Models
         public override string Name { get; set; } = null!;
 
         /// <inheritdoc/>
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, IGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<IGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         public IGroupInfo Group { get; set; } = null!;
 
@@ -124,7 +124,7 @@ namespace Mirai.CSharp.HttpApi.Models
             MuteTimeRemaining = muteTimeRemaining;
         }
 #if NETSTANDARD2_0
-        [JsonConverter(typeof(ChangeTypeJsonConverter<GroupInfo, ISharedGroupInfo>))]
+        [JsonConverter(typeof(ChangeTypeJsonConverter<ISharedGroupInfo, GroupInfo>))]
         [JsonPropertyName("group")]
         ISharedGroupInfo ISharedGroupMemberInfo.Group => Group;
 #endif

--- a/Mirai-CSharp.HttpApi/Models/UserProfile.cs
+++ b/Mirai-CSharp.HttpApi/Models/UserProfile.cs
@@ -3,7 +3,7 @@ using ISharedUserProfile = Mirai.CSharp.Models.IUserProfile;
 
 namespace Mirai.CSharp.HttpApi.Models
 {
-    /// <inheritdoc cref="ISharedFriendProfile"/>
+    /// <inheritdoc cref="ISharedUserProfile"/>
     public interface IUserProfile : ISharedUserProfile, ICommonProfile
     {
 

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.FetchProfile.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.FetchProfile.cs
@@ -41,7 +41,7 @@ namespace Mirai.CSharp.HttpApi.Session
             {
                 throw new System.NotSupportedException("本接口仅在 mirai-api-http v2.4.0 及以上版本提供");
             }
-            return _client.GetAsync($"{_options.BaseUrl}/userProfile?sessionKey={session.SessionKey}&userId={qqNumber}", token)
+            return _client.GetAsync($"{_options.BaseUrl}/userProfile?sessionKey={session.SessionKey}&target={qqNumber}", token)
                 .AsApiRespAsync<ISharedUserProfile, UserProfile>(token)
                 .DisposeWhenCompleted(cts);
         }

--- a/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.cs
+++ b/Mirai-CSharp.HttpApi/Session/MiraiHttpSession.cs
@@ -114,11 +114,7 @@ namespace Mirai.CSharp.HttpApi.Session
 
         private static void CreateLinkedUserSessionToken(CancellationToken sessionToken,
                                                          CancellationToken userToken,
-#if NETSTANDARD2_0
                                                          out CancellationTokenSource? cts,
-#else
-                                                         [NotNullWhen(true)]out CancellationTokenSource? cts,
-#endif
                                                          out CancellationToken finalToken)
         {
             if (userToken == default)

--- a/Mirai-CSharp.HttpApi/Utility/JsonConverters/ChangeTypeJsonConverter.cs
+++ b/Mirai-CSharp.HttpApi/Utility/JsonConverters/ChangeTypeJsonConverter.cs
@@ -4,16 +4,21 @@ using System.Text.Json.Serialization;
 
 namespace Mirai.CSharp.HttpApi.Utility.JsonConverters
 {
-    public class ChangeTypeJsonConverter<TSrc, TDst> : JsonConverter<TDst> where TSrc : TDst
+    public class ChangeTypeJsonConverter<TFrom, TTo> : ChangeTypeJsonConverter<TFrom, object, TTo> where TFrom : notnull where TTo : TFrom
     {
-        public override TDst Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        
+    }
+
+    public class ChangeTypeJsonConverter<TFrom, TSerializeTo, TDeserializeTo> : JsonConverter<TFrom> where TDeserializeTo : TFrom where TFrom : notnull, TSerializeTo
+    {
+        public override TFrom Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
         {
-            return JsonSerializer.Deserialize<TSrc>(ref reader, options)!;
+            return JsonSerializer.Deserialize<TDeserializeTo>(ref reader, options)!;
         }
 
-        public override void Write(Utf8JsonWriter writer, TDst value, JsonSerializerOptions options)
+        public override void Write(Utf8JsonWriter writer, TFrom value, JsonSerializerOptions options)
         {
-            JsonSerializer.Serialize<object>(writer, value!, options); // TDst : interface 时, 不使用object的泛型参数将导致基接口成员不会被序列化
+            JsonSerializer.Serialize<TSerializeTo>(writer, value!, options);
         }
     }
 }

--- a/Mirai-CSharp/Builders/ForwardMessageBuilder.cs
+++ b/Mirai-CSharp/Builders/ForwardMessageBuilder.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using Mirai.CSharp.Models.ChatMessages;
+
+namespace Mirai.CSharp.Builders
+{
+    /// <summary>
+    /// 用于构建一个转发消息的接口
+    /// </summary>
+    public interface IForwardMessageBuilder : IEnumerable<IForwardMessageNode>
+    {
+        /// <summary>
+        /// 已添加的消息节点计数
+        /// </summary>
+        int Count { get; }
+
+        /// <summary>
+        /// 使用已添加的所有消息节点创建一个 <see cref="IForwardMessage"/> 实例
+        /// </summary>
+        /// <returns>一个 <see cref="IForwardMessage"/> 实例, 可用于消息发送</returns>
+        IForwardMessage Build();
+
+        /// <summary>
+        /// 为当前的 <see cref="IForwardMessageBuilder"/> 添加一条现有的 <see cref="IForwardMessageNode"/>
+        /// </summary>
+        /// <param name="node">欲添加的现有 <see cref="IForwardMessageNode"/> 实例</param>
+        /// <returns>传入的 <see cref="IForwardMessageBuilder"/> 实例, 可继续用于链式调用</returns>
+        IForwardMessageBuilder AddNode(IForwardMessageNode node);
+
+        /// <summary>
+        /// 为当前的 <see cref="IForwardMessageBuilder"/> 添加一些现有的 <see cref="IForwardMessageNode"/>
+        /// </summary>
+        /// <param name="nodes">一个 <see cref="IForwardMessageNode"/> 集合, 其中所有的实例都将添加进本构建器</param>
+        /// <returns>传入的 <see cref="IForwardMessageBuilder"/> 实例, 可继续用于链式调用</returns>
+        IForwardMessageBuilder AddNodes(IEnumerable<IForwardMessageNode> nodes);
+
+        /// <summary>
+        /// 为当前的 <see cref="IForwardMessageBuilder"/> 添加一条相同Id的消息
+        /// </summary>
+        /// <param name="id">消息Id</param>
+        /// <returns>传入的 <see cref="IForwardMessageBuilder"/> 实例, 可继续用于链式调用</returns>
+        IForwardMessageBuilder AddNode(int id);
+
+        /// <summary>
+        /// 为当前的 <see cref="IForwardMessageBuilder"/> 添加一条消息
+        /// </summary>
+        /// <param name="name">来源昵称</param>
+        /// <param name="qqNumber">来源QQ</param>
+        /// <param name="time">消息发送时间</param>
+        /// <param name="chainBuilder">消息具体内容构建器</param>
+        /// <returns>传入的 <see cref="IForwardMessageBuilder"/> 实例, 可继续用于链式调用</returns>
+        IForwardMessageBuilder AddNode(string name, long qqNumber, DateTime time, IMessageChainBuilder chainBuilder);
+
+        /// <summary>
+        /// 为当前的 <see cref="IForwardMessageBuilder"/> 添加一条消息
+        /// </summary>
+        /// <param name="name">来源昵称</param>
+        /// <param name="qqNumber">来源QQ</param>
+        /// <param name="time">消息发送时间</param>
+        /// <param name="messages">一系列的具体消息</param>
+        /// <returns>传入的 <see cref="IForwardMessageBuilder"/> 实例, 可继续用于链式调用</returns>
+        IForwardMessageBuilder AddNode(string name, long qqNumber, DateTime time, params IChatMessage[] messages);
+    }
+
+    /// <summary>
+    /// 用于构建一个转发消息的抽象基类
+    /// </summary>
+    public abstract class ForwardMessageBuilder : IForwardMessageBuilder
+    {
+        /// <inheritdoc/>
+        public virtual int Count => _nodes.Count;
+
+        protected readonly List<IForwardMessageNode> _nodes = new List<IForwardMessageNode>();
+
+        /// <inheritdoc/>
+        public abstract IForwardMessage Build();
+
+        /// <inheritdoc/>
+        public virtual IForwardMessageBuilder AddNode(IForwardMessageNode node)
+        {
+            _nodes.Add(node);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public virtual IForwardMessageBuilder AddNodes(IEnumerable<IForwardMessageNode> nodes)
+        {
+            _nodes.AddRange(nodes);
+            return this;
+        }
+
+        /// <inheritdoc/>
+        public virtual IEnumerator<IForwardMessageNode> GetEnumerator()
+        {
+            return _nodes.GetEnumerator();
+        }
+
+        /// <inheritdoc/>
+        public abstract IForwardMessageBuilder AddNode(int id);
+
+        /// <inheritdoc/>
+        public abstract IForwardMessageBuilder AddNode(string name, long qqNumber, DateTime time, IMessageChainBuilder chainBuilder);
+
+        /// <inheritdoc/>
+        public abstract IForwardMessageBuilder AddNode(string name, long qqNumber, DateTime time, params IChatMessage[] messages);
+
+        /// <inheritdoc/>
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return GetEnumerator();
+        }
+    }
+}

--- a/Mirai-CSharp/Builders/MessageChainBuilder.cs
+++ b/Mirai-CSharp/Builders/MessageChainBuilder.cs
@@ -13,13 +13,30 @@ namespace Mirai.CSharp.Builders
     /// </remarks>
     public interface IMessageChainBuilder : IEnumerable<IChatMessage>
     {
+        /// <summary>
+        /// 已添加的消息计数
+        /// </summary>
         int Count { get; }
 
+        /// <summary>
+        /// 使用已添加的所有消息节点创建一个 <see cref="IChatMessage"/>[] 实例
+        /// </summary>
+        /// <returns>一个 <see cref="IChatMessage"/>[] 实例, 可用于消息发送</returns>
         IChatMessage[] Build();
 
+        /// <summary>
+        /// 为当前的 <see cref="IMessageChainBuilder"/> 添加一条现有的 <see cref="IChatMessage"/>
+        /// </summary>
+        /// <param name="message"></param>
+        /// <returns>传入的 <see cref="IMessageChainBuilder"/> 实例, 可继续用于链式调用</returns>
         IMessageChainBuilder Add(IChatMessage message);
 
-        IMessageChainBuilder AddRange(IEnumerable<IChatMessage> message);
+        /// <summary>
+        /// 为当前的 <see cref="IMessageChainBuilder"/> 添加一些现有的 <see cref="IChatMessage"/>
+        /// </summary>
+        /// <param name="messages">一个 <see cref="IChatMessage"/> 集合, 其中所有的实例都将添加进本构建器</param>
+        /// <returns>传入的 <see cref="IMessageChainBuilder"/> 实例, 可继续用于链式调用</returns>
+        IMessageChainBuilder AddRange(IEnumerable<IChatMessage> messages);
 
         /// <summary>
         /// 为给定的 <see cref="IMessageChainBuilder"/> 添加一条 <see cref="IPlainMessage"/>
@@ -93,6 +110,13 @@ namespace Mirai.CSharp.Builders
         IMessageChainBuilder AddFaceMessage(int id, string? name = null);
 
         /// <summary>
+        /// 为给定的 <see cref="IMessageChainBuilder"/> 添加一条 <see cref="IForwardMessage"/>
+        /// </summary>
+        /// <param name="builder">用于构建 <see cref="IForwardMessage"/> 的构建器实例</param>
+        /// <returns>传入的 <see cref="IMessageChainBuilder"/>, 可继续用于链式调用</returns>
+        IMessageChainBuilder AddForwardMessage(IForwardMessageBuilder builder);
+
+        /// <summary>
         /// 为给定的 <see cref="IMessageChainBuilder"/> 添加一条 <see cref="IXmlMessage"/>
         /// </summary>
         /// <param name="xml">xml原始字符串</param>
@@ -143,6 +167,12 @@ namespace Mirai.CSharp.Builders
         /// </remarks>
         /// <returns>传入的 <see cref="IMessageChainBuilder"/>, 可继续用于链式调用</returns>
         IMessageChainBuilder AddVoiceMessage(string? voiceId = null, string? url = null, string? path = null);
+
+        /// <summary>
+        /// 获取用于创建适用于本实例的 <see cref="IForwardMessage"/> 构建器实例
+        /// </summary>
+        /// <returns>一个合适的 <see cref="IForwardMessageBuilder"/> 实例</returns>
+        IForwardMessageBuilder GetForwardMessageBuilder();
     }
 
     /// <summary>
@@ -152,23 +182,28 @@ namespace Mirai.CSharp.Builders
     {
         protected readonly List<IChatMessage> _list = new List<IChatMessage>();
 
+        /// <inheritdoc/>
         public virtual int Count => _list.Count;
 
+        /// <inheritdoc/>
         public virtual IChatMessage[] Build()
             => _list.ToArray();
 
+        /// <inheritdoc/>
         public virtual IMessageChainBuilder Add(IChatMessage message)
         {
             _list.Add(message);
             return this;
         }
 
-        public virtual IMessageChainBuilder AddRange(IEnumerable<IChatMessage> message)
+        /// <inheritdoc/>
+        public virtual IMessageChainBuilder AddRange(IEnumerable<IChatMessage> messages)
         {
-            _list.AddRange(message);
+            _list.AddRange(messages);
             return this;
         }
 
+        /// <inheritdoc/>
         public virtual IEnumerator<IChatMessage> GetEnumerator()
         {
             return _list.GetEnumerator();
@@ -193,6 +228,9 @@ namespace Mirai.CSharp.Builders
         public abstract IMessageChainBuilder AddFaceMessage(int id, string? name = null);
 
         /// <inheritdoc/>
+        public abstract IMessageChainBuilder AddForwardMessage(IForwardMessageBuilder builder);
+
+        /// <inheritdoc/>
         public abstract IMessageChainBuilder AddXmlMessage(string xml);
 
         /// <inheritdoc/>
@@ -207,6 +245,10 @@ namespace Mirai.CSharp.Builders
         /// <inheritdoc/>
         public abstract IMessageChainBuilder AddVoiceMessage(string? voiceId = null, string? url = null, string? path = null);
 
+        /// <inheritdoc/>
+        public abstract IForwardMessageBuilder GetForwardMessageBuilder();
+
+        /// <inheritdoc/>
         IEnumerator IEnumerable.GetEnumerator()
         {
             return GetEnumerator();


### PR DESCRIPTION
close #132 
close #133 

- 解决 `MiraiHttpSession.GetUserProfileAsync` 调用错误的问题
- 修正xml标注错误 
- 修复转发消息无法正常发送的问题
- 更改 `ChangeTypeJsonConverter` 定义, 并添加一个三泛型参数的 `ChangeTypeJsonConverter` 以便更好控制(反)序列化
- 添加转发消息构建器 `(I)ForwardMessageBuilder`